### PR TITLE
Suggestion: Zone 2 should perhaps be optional

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -875,7 +875,7 @@ MIDEA_DEVICES = {
                 "icon": "mdi:air-conditioner",
                 "name": "Zone2 Thermostat",
                 "zone": 1,
-                "default": True,
+                "default": False,
             },
             "water_heater": {
                 "type": Platform.WATER_HEATER,


### PR DESCRIPTION
Suggestion: Zone 2 should perhaps be optional as this is not active with every heat pump.