### PR TITLE
chore(hacs): revert required homeassistant version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "name": "Midea AC LAN",
     "render_readme": true,
-    "homeassistant": "2022.5",
+    "homeassistant": "2023.1",
     "zip_release": true,
     "filename": "midea_ac_lan.zip"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "name": "Midea AC LAN",
     "render_readme": true,
-    "homeassistant": "2024.5",
+    "homeassistant": "2022.5",
     "zip_release": true,
     "filename": "midea_ac_lan.zip"
 }


### PR DESCRIPTION
# PR Description
2022.5 was the previously required version. IDK why it was updated to 2024.4. Is there something that only works on 2024.4?

## Reason & Detail

## Releted issue

fix #24 