### PR TITLE
fix: Flow handler not found for entry xxxx for midea_ac_lan

### DIFF
--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -70,7 +70,7 @@ PRESET_ACCOUNT = [
 ]
 
 
-class ConfigFlow(config_entries.ConfigFlow):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     available_device: list = []
     devices: dict = {}
     found_device: dict = {}


### PR DESCRIPTION
# PR Description

fix: Error: Flow handler not found for entry xxxx for midea_ac_lan

## Reason & Detail

https://github.com/wuwentao/midea_ac_lan/commit/8f24cadc522e4213456cf6c287353f4c8b53ea48#diff-f5d8707f0a5c6f23f230428526ed086afb1199041d6b903c248e5e44bbca42d5L73