### PR TITLE
fix lint error after PR merged to master

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,7 +2,7 @@
 name: Lint
 
 on: # yamllint disable-line rule:truthy
-  push: null
+  # push: null
   pull_request: null
 
 permissions: {}
@@ -26,7 +26,7 @@ jobs:
           # list of files that changed across commits
           fetch-depth: 0
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
# PR Description
1. lint will rerun after PR merged to master, it will caused pre-commit error,  disable push check before it can works.
2. upgrade setup-python to new version as warning msg in github action:
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

## Reason & Detail

## Related issue

fix #X

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
