### PR TITLE
build: disable black

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,5 +42,5 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_PYTHON_MYPY: false
-          # VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_BLACK: false
           # VALIDATE_PYTHON_ISORT: false


### PR DESCRIPTION
Disable `black` to avoid conflicts with `ruff` that is enable as a pre-commit hook.
