### PR TITLE
fix: exclude de.json for pre-commit codespell check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
     hooks:
       - id: codespell
         args: ["-L hass", "-w"]
+        exclude: "custom_components/midea_ac_lan/translations/de.json" # only de.json can't work with codespell
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
     hooks:


### PR DESCRIPTION
# PR Description
pre-commit codespell can't works for de.json
seems only one json file can't works now, just ignore this file in pre-commit config.

## Reason & Detail
#60 PR can't pass pre-commit codespell, it should be an error.
just ignore this file

## Related issue

fix #X

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
