### PR TITLE
fix: fan is_on error and maximum recursion error log consumed all disk space

### DIFF
--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEVICE_ID, CONF_SWITCHES, STATE_ON, Platform
+from homeassistant.const import CONF_DEVICE_ID, CONF_SWITCHES, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from midealocal.devices.ac import DeviceAttributes as ACAttributes
@@ -156,7 +156,7 @@ class MideaACFreshAirFan(MideaFan):
 
     @property
     def is_on(self) -> bool:
-        return self.state == STATE_ON
+        return cast(bool, self._device.get_attribute(ACAttributes.fresh_air_power))
 
     @property
     def fan_speed(self) -> int:

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -216,6 +216,10 @@ class Midea40Fan(MideaFan):
         )
         self._attr_speed_count = 2
 
+    @property
+    def is_on(self) -> bool:
+        return self._device.get_attribute(attr=X40Attributes.fan_speed) > 0
+
     def turn_on(
         self,
         percentage: int | None = None,

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -218,7 +218,7 @@ class Midea40Fan(MideaFan):
 
     @property
     def is_on(self) -> bool:
-        return self._device.get_attribute(attr=X40Attributes.fan_speed) > 0
+        return cast(int, self._device.get_attribute(attr=X40Attributes.fan_speed)) > 0
 
     def turn_on(
         self,


### PR DESCRIPTION
# PR Description

as #63 description 
```
File "/config/custom_components/midea_ac_lan/fan.py", line 159, in is_on
return self.state == STATE_ON
```

`RecursionError: maximum recursion depth exceeded`

## Reason & Detail

checked with commit history, should be introduced with mypy changes:
https://github.com/wuwentao/midea_ac_lan/commit/e804cd251a67c22480c7940c0330e9581061e68b

is_on return bool
use the same method as base class MideaFan.is_on
and  set the value with `fresh_air_power` from the commit history

## Related issue

fix #63 

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
