### PR TITLE
awaiting `async_forward_entry_setups`

### DIFF
--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -234,9 +234,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             hass.data[DOMAIN][DEVICES] = {}
         hass.data[DOMAIN][DEVICES][device_id] = device
         # Forward the setup of an entry to all platforms
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setups(config_entry, ALL_PLATFORM),
-        )
+        await hass.config_entries.async_forward_entry_setups(config_entry, ALL_PLATFORM)
         # Listener `update_listener` is attached when the entry is loaded and detached at unload
         config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
         return True


### PR DESCRIPTION
# PR Description

`hass.config_entries.async_forward_entry_setups` must always be awaited

## Reason & Detail

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups
https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/
