### PR TITLE
feat: bump midea_local to 1.0.5

### DIFF
--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
-  "requirements": ["pycryptodome", "midea-local==1.0.3"],
+  "requirements": ["pycryptodome", "midea-local==1.0.5"],
   "version": "v0.4.1"
 }


### PR DESCRIPTION

Bump upstream library to 1.0.5:

changelog: https://github.com/rokam/midea-local/releases/tag/v1.0.5
diff: https://github.com/rokam/midea-local/compare/v1.0.3...v1.0.5

NOTE: Please test both already registered devices and new device registration before releasing a new component version