### PR TITLE
fix compatibility with python 3.11

### DIFF
--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -266,10 +266,9 @@ class MideaLanConfigFlow(ConfigFlow, domain=DOMAIN):
             for device_id, device in self.devices.items():
                 # remove exist devices and only return new devices
                 if not self._already_configured(device_id, device.get(CONF_IP_ADDRESS)):
-                    self.available_device[
-                        device_id
-                    ] = f"{device_id} ({self.supports.get(
-                            device.get(CONF_TYPE))})"
+                    self.available_device[device_id] = (
+                        f"{device_id} ({self.supports.get(device.get(CONF_TYPE))})"
+                    )
             if len(self.available_device) > 0:
                 return await self.async_step_auto()
             return await self.async_step_discovery(error="no_devices")


### PR DESCRIPTION
# PR Description

Fix compatibility with python 3.11

## Reason & Detail

Python version 3.11 does not allow new lines in expression parts of non-triple-quoted f-strings

## Related issue

fix #91 

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
