### PR TITLE
fix: temporary revert typing

### DIFF
--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -40,7 +40,7 @@ class MideaEntity(Entity):
             "model": f"{MIDEA_DEVICES[self._device.device_type]['name']} "
             f"{self._device.model}"
             f" ({self._device.subtype})",
-            "identifiers": {(DOMAIN, str(self._device.device_id))},
+            "identifiers": {(DOMAIN, self._device.device_id)},  # type: ignore[arg-type]
             "name": self._device_name,
         }
 


### PR DESCRIPTION
The correct typing of the line of code needs a migration of the identifier that currently is wrongly stored as a integer.

For this reason we temporary revert the code to the previous behaviour, so to make a new fully working release and test all the other changes.

