### PR TITLE
fix: access customize dict key error when default is None

### DIFF
--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -188,7 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     model: str = config_entry.data[CONF_MODEL]
     subtype = config_entry.data.get(CONF_SUBTYPE, 0)
     protocol: int = config_entry.data[CONF_PROTOCOL]
-    customize: str = config_entry.options[CONF_CUSTOMIZE]
+    customize: str = config_entry.options.get(CONF_CUSTOMIZE, "")
     if protocol == 3 and (key == "" or token == ""):
         _LOGGER.error("For V3 devices, the key and the token is required")
         return False


### PR DESCRIPTION
# PR Description
```
2024-06-20 12:15:04.249 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry 客厅空调 for midea_ac_lan
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/config_entries.py", line 594, in async_setup
result = await component.async_setup_entry(hass, self)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/midea_ac_lan/__init__.py", line 191, in async_setup_entry
customize: str = config_entry.options[CONF_CUSTOMIZE]
~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'customize'
```

## Reason & Detail

update 
`
customize: str = config_entry.options[CONF_CUSTOMIZE] 
`
to :

`
customize: str = config_entry.options.get(CONF_CUSTOMIZE, "")
`

## Related issue

fix #X

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
