### PR TITLE
fix: migrate identifier

### DIFF
--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any, cast
 
 import homeassistant.helpers.config_validation as cv
+import homeassistant.helpers.device_registry as dr
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -258,3 +259,66 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     # Forward the unloading of an entry to platforms
     await hass.config_entries.async_unload_platforms(config_entry, ALL_PLATFORM)
     return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    # 1.0 -> 1.1:  convert device identifiers from int to str
+    if config_entry.version == 1 and config_entry.minor_version == 0:
+        hass.config_entries.async_update_entry(config_entry, minor_version=1)
+
+        # Migrate device.
+        await _async_migrate_device_identifiers(hass, config_entry)
+
+        _LOGGER.debug("Migration to configuration version 1.1 successful")
+
+    _LOGGER.debug(
+        "Migration to configuration version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    return True
+
+
+async def _async_migrate_device_identifiers(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> None:
+    """Migrate the device identifiers to the new format."""
+    device_registry = dr.async_get(hass)
+    device_entry_found = False
+    for device_entry in dr.async_entries_for_config_entry(
+        device_registry,
+        config_entry.entry_id,
+    ):
+        for identifier in device_entry.identifiers:
+            # Device found in registry. Update identifiers.
+            new_identifiers = {
+                (
+                    DOMAIN,
+                    str(identifier[1]),
+                ),
+            }
+            _LOGGER.debug(
+                "Migrating device identifiers from %s to %s",
+                device_entry.identifiers,
+                new_identifiers,
+            )
+            device_registry.async_update_device(
+                device_id=device_entry.id,
+                new_identifiers=new_identifiers,
+            )
+            # Device entry found. Leave inner for loop.
+            device_entry_found = True
+            break
+
+        # Leave outer for loop if device entry is already found.
+        if device_entry_found:
+            break

--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -101,6 +101,9 @@ class MideaLanConfigFlow(ConfigFlow, domain=DOMAIN):
     ConfigFlow will manage the creation of entries from user input, discovery
     """
 
+    VERSION = 2
+    MINOR_VERSION = 1
+
     def __init__(self) -> None:
         """MideaLanConfigFlow class."""
         self.available_device: dict = {}

--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -48,7 +48,7 @@ class MideaEntity(Entity):
             "model": f"{MIDEA_DEVICES[self._device.device_type]['name']} "
             f"{self._device.model}"
             f" ({self._device.subtype})",
-            "identifiers": {(DOMAIN, self._device.device_id)},  # type: ignore[arg-type]
+            "identifiers": {(DOMAIN, str(self._device.device_id))},
             "name": self._device_name,
         }
 


### PR DESCRIPTION
# PR Description

Fixing device registry because of a faulty value: device id was wrongly stored as a int.

Old:    `"identifiers":[["midea_ac_lan",146235046630005]]`

New:  `"identifiers":[["midea_ac_lan","146235046630005"]]`
