### PR TITLE
fix: dockerfile arg error

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,10 @@
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# Declare the build argument VARIANT in the global scope, can be overwrite with devcontainer.json build args
 ARG VARIANT=3.12
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}-bullseye
 
+# Consume the build argument in the build stage from global scope
+ARG VARIANT
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi


### PR DESCRIPTION
# PR Description

```
 => ERROR [dev_container_auto_added_stage_label 4/4] RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements-all-${VARIANT}.txt    && rm -rf /tmp/pip-tmp                                                                                                                                                                  1.5s
------                                                                                                                                                                                                                                                                                                                                                           
 > [dev_container_auto_added_stage_label 4/4] RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements-all-${VARIANT}.txt    && rm -rf /tmp/pip-tmp:
#0 1.142 ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/tmp/pip-tmp/requirements-all-.txt'
------
Dockerfile-with-features:13
```

## Reason & Detail

## Related issue

fix #X

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
