### PR TITLE
fix: remove duplicate python3.12 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,10 @@
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# Declare the build argument VARIANT in the global scope, can be overwrite with devcontainer.json build args
 ARG VARIANT=3.12
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}-bullseye
 
+# Consume the build argument in the build stage from global scope
+ARG VARIANT
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
       "settings": {
         "files.eol": "\n",
         "editor.tabSize": 4,
-        "python.pythonPath": "/usr/bin/python3",
+        "python.pythonPath": "/usr/local/bin/python3",
         "python.analysis.autoSearchPaths": false,
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
@@ -33,10 +33,5 @@
       }
     }
   },
-  "remoteUser": "vscode",
-  "features": {
-    "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.12"
-    }
-  }
+  "remoteUser": "vscode"
 }


### PR DESCRIPTION
# PR Description

we have installed both python3.12 in devcontainer

## Reason & Detail

our `Dockerfile` base image is `python3.12`, and the base os already have builtin `python3.12`,  and install all the requirements via our local repo `requirement-all-xxx.txt` file.

but `devcontainer.json` still installed a duplicate `python3.12` to the base os and caused default python3 and pip can't work.

just remove it and keep only one python3.12.

## Related issue

fix #X

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
