### PR TITLE
feat: new entity naming

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -1918,14 +1918,23 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
     0xED: {
         "name": "Water Drinking Appliance",
         "entities": {
-            EDAttributes.child_lock: {"type": Platform.LOCK, "name": "Child Lock"},
+            EDAttributes.child_lock: {
+                "type": Platform.LOCK,
+                "has_entity_name": True,
+                "translation_key": "child_lock",
+                "name": "Child Lock",
+            },
             EDAttributes.power: {
                 "type": Platform.SWITCH,
+                "has_entity_name": True,
+                "translation_key": "power",
                 "name": "Power",
                 "icon": "mdi:power",
             },
             EDAttributes.filter1: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "filter1_days",
                 "name": "Filter1 Available Days",
                 "icon": "mdi:air-filter",
                 "unit": UnitOfTime.DAYS,
@@ -1933,6 +1942,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.filter2: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "filter2_days",
                 "name": "Filter2 Available Days",
                 "icon": "mdi:air-filter",
                 "unit": UnitOfTime.DAYS,
@@ -1940,6 +1951,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.filter3: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "filter3_days",
                 "name": "Filter3 Available Days",
                 "icon": "mdi:air-filter",
                 "unit": UnitOfTime.DAYS,
@@ -1947,6 +1960,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.life1: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "filter1_life",
                 "name": "Filter1 Life Level",
                 "icon": "mdi:percent",
                 "unit": PERCENTAGE,
@@ -1954,6 +1969,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.life2: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "filter2_life",
                 "name": "Filter2 Life Level",
                 "icon": "mdi:percent",
                 "unit": PERCENTAGE,
@@ -1961,6 +1978,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.life3: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "filter3_life",
                 "name": "Filter3 Life Level",
                 "icon": "mdi:percent",
                 "unit": PERCENTAGE,
@@ -1968,6 +1987,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.in_tds: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "in_tds",
                 "name": "In TDS",
                 "icon": "mdi:water",
                 "unit": CONCENTRATION_PARTS_PER_MILLION,
@@ -1975,6 +1996,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.out_tds: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "out_tds",
                 "name": "Out TDS",
                 "icon": "mdi:water-plus",
                 "unit": CONCENTRATION_PARTS_PER_MILLION,
@@ -1982,6 +2005,8 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             EDAttributes.water_consumption: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
+                "translation_key": "water_consumption",
                 "name": "Water Consumption",
                 "icon": "mdi:water-pump",
                 "unit": UnitOfVolume.LITERS,

--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -35,6 +35,15 @@ class MideaEntity(Entity):
         self.entity_id = self._unique_id
         self._device_name = self._device.name
 
+        self._attr_translation_key = self._config.get("translation_key")
+        self._attr_has_entity_name = self._config.get("has_entity_name", False)
+        if not self.has_entity_name:  # old behavior
+            self._attr_name = (
+                f"{self._device_name} {self._config.get('name')}"
+                if "name" in self._config
+                else self._device_name
+            )
+
     @property
     def device(self) -> MideaDevice:
         """Return device structure."""
@@ -61,15 +70,6 @@ class MideaEntity(Entity):
     def should_poll(self) -> bool:
         """Return true is integration should poll."""
         return False
-
-    @property
-    def name(self) -> str:
-        """Return entity name."""
-        return (
-            f"{self._device_name} {self._config.get('name')}"
-            if "name" in self._config
-            else self._device_name
-        )
 
     @property
     def available(self) -> bool:

--- a/custom_components/midea_ac_lan/translations/de.json
+++ b/custom_components/midea_ac_lan/translations/de.json
@@ -61,6 +61,47 @@
       }
     }
   },
+  "entity": {
+    "lock": {
+      "child_lock": {
+        "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "filter1_days": {
+        "name": "Filter1 Available Days"
+      },
+      "filter2_days": {
+        "name": "Filter2 Available Days"
+      },
+      "filter3_days": {
+        "name": "Filter3 Available Days"
+      },
+      "filter1_life": {
+        "name": "Filter1 Life Level"
+      },
+      "filter2_life": {
+        "name": "Filter2 Life Level"
+      },
+      "filter3_life": {
+        "name": "Filter3 Life Level"
+      },
+      "in_tds": {
+        "name": "In TDS"
+      },
+      "out_tds": {
+        "name": "Out TDS"
+      },
+      "water_consumption": {
+        "name": "Water Consumption"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/midea_ac_lan/translations/en.json
+++ b/custom_components/midea_ac_lan/translations/en.json
@@ -61,6 +61,47 @@
       }
     }
   },
+  "entity": {
+    "lock": {
+      "child_lock": {
+        "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "filter1_days": {
+        "name": "Filter1 Available Days"
+      },
+      "filter2_days": {
+        "name": "Filter2 Available Days"
+      },
+      "filter3_days": {
+        "name": "Filter3 Available Days"
+      },
+      "filter1_life": {
+        "name": "Filter1 Life Level"
+      },
+      "filter2_life": {
+        "name": "Filter2 Life Level"
+      },
+      "filter3_life": {
+        "name": "Filter3 Life Level"
+      },
+      "in_tds": {
+        "name": "In TDS"
+      },
+      "out_tds": {
+        "name": "Out TDS"
+      },
+      "water_consumption": {
+        "name": "Water Consumption"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/midea_ac_lan/translations/fr.json
+++ b/custom_components/midea_ac_lan/translations/fr.json
@@ -61,6 +61,47 @@
       }
     }
   },
+  "entity": {
+    "lock": {
+      "child_lock": {
+        "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "filter1_days": {
+        "name": "Filter1 Available Days"
+      },
+      "filter2_days": {
+        "name": "Filter2 Available Days"
+      },
+      "filter3_days": {
+        "name": "Filter3 Available Days"
+      },
+      "filter1_life": {
+        "name": "Filter1 Life Level"
+      },
+      "filter2_life": {
+        "name": "Filter2 Life Level"
+      },
+      "filter3_life": {
+        "name": "Filter3 Life Level"
+      },
+      "in_tds": {
+        "name": "In TDS"
+      },
+      "out_tds": {
+        "name": "Out TDS"
+      },
+      "water_consumption": {
+        "name": "Water Consumption"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/midea_ac_lan/translations/hu.json
+++ b/custom_components/midea_ac_lan/translations/hu.json
@@ -61,6 +61,47 @@
       }
     }
   },
+  "entity": {
+    "lock": {
+      "child_lock": {
+        "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "filter1_days": {
+        "name": "Filter1 Available Days"
+      },
+      "filter2_days": {
+        "name": "Filter2 Available Days"
+      },
+      "filter3_days": {
+        "name": "Filter3 Available Days"
+      },
+      "filter1_life": {
+        "name": "Filter1 Life Level"
+      },
+      "filter2_life": {
+        "name": "Filter2 Life Level"
+      },
+      "filter3_life": {
+        "name": "Filter3 Life Level"
+      },
+      "in_tds": {
+        "name": "In TDS"
+      },
+      "out_tds": {
+        "name": "Out TDS"
+      },
+      "water_consumption": {
+        "name": "Water Consumption"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/midea_ac_lan/translations/ru.json
+++ b/custom_components/midea_ac_lan/translations/ru.json
@@ -61,6 +61,47 @@
       }
     }
   },
+  "entity": {
+    "lock": {
+      "child_lock": {
+        "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "filter1_days": {
+        "name": "Filter1 Available Days"
+      },
+      "filter2_days": {
+        "name": "Filter2 Available Days"
+      },
+      "filter3_days": {
+        "name": "Filter3 Available Days"
+      },
+      "filter1_life": {
+        "name": "Filter1 Life Level"
+      },
+      "filter2_life": {
+        "name": "Filter2 Life Level"
+      },
+      "filter3_life": {
+        "name": "Filter3 Life Level"
+      },
+      "in_tds": {
+        "name": "In TDS"
+      },
+      "out_tds": {
+        "name": "Out TDS"
+      },
+      "water_consumption": {
+        "name": "Water Consumption"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/midea_ac_lan/translations/sk.json
+++ b/custom_components/midea_ac_lan/translations/sk.json
@@ -61,6 +61,47 @@
       }
     }
   },
+  "entity": {
+    "lock": {
+      "child_lock": {
+        "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "filter1_days": {
+        "name": "Filter1 Available Days"
+      },
+      "filter2_days": {
+        "name": "Filter2 Available Days"
+      },
+      "filter3_days": {
+        "name": "Filter3 Available Days"
+      },
+      "filter1_life": {
+        "name": "Filter1 Life Level"
+      },
+      "filter2_life": {
+        "name": "Filter2 Life Level"
+      },
+      "filter3_life": {
+        "name": "Filter3 Life Level"
+      },
+      "in_tds": {
+        "name": "In TDS"
+      },
+      "out_tds": {
+        "name": "Out TDS"
+      },
+      "water_consumption": {
+        "name": "Water Consumption"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/midea_ac_lan/translations/zh-Hans.json
+++ b/custom_components/midea_ac_lan/translations/zh-Hans.json
@@ -61,6 +61,47 @@
       }
     }
   },
+  "entity": {
+    "lock": {
+      "child_lock": {
+        "name": "童锁"
+      }
+    },
+    "sensor": {
+      "filter1_days": {
+        "name": "滤芯1可用天数"
+      },
+      "filter2_days": {
+        "name": "滤芯2可用天数"
+      },
+      "filter3_days": {
+        "name": "滤芯3可用天数"
+      },
+      "filter1_life": {
+        "name": "滤芯1剩余寿命"
+      },
+      "filter2_life": {
+        "name": "滤芯2剩余寿命"
+      },
+      "filter3_life": {
+        "name": "滤芯3剩余寿命"
+      },
+      "in_tds": {
+        "name": "进水TDS"
+      },
+      "out_tds": {
+        "name": "出水TDS"
+      },
+      "water_consumption": {
+        "name": "总耗水量"
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "电源开关"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION
# PR Description

This PR introduces the new way of [entity naming](https://developers.home-assistant.io/docs/core/entity/#entity-naming).

> Avoid setting an entity's name to a hard coded English string, instead, the name should be [translated](https://developers.home-assistant.io/docs/internationalization/core#name-of-entities).

## Reason & Detail

Here gives an example of `ED` device in `en` and `zh-Hans` (other languages simply copy `en`),

for a smooth migration, manually set `"has_entity_name": True` to use the new naming method, otherwise keep the original behavior.

`translation_key` can be `None`, which represents [the **main feature** of a device](https://developers.home-assistant.io/docs/core/entity/#example-of-a-switch-entity-which-is-the-main-feature-of-a-device).

Fully entity naming will be a huge task or may be done in later PRs.

## Related issue

#98 