### PR TITLE
build:  cleanup  requirements and add missing ones

### DIFF
--- a/requirements-dev-3.11.txt
+++ b/requirements-dev-3.11.txt
@@ -1,5 +1,3 @@
+-r requirements-dev.txt
+
 homeassistant==2024.3.3
-mypy-dev==1.11.0a6
-pydantic==1.10.15
-pre-commit==3.7.1
-ruff==0.4.9

--- a/requirements-dev-3.12.txt
+++ b/requirements-dev-3.12.txt
@@ -1,6 +1,3 @@
-homeassistant==2024.5.1
-mypy-dev==1.11.0a6
-pydantic==1.10.15
-pre-commit==3.7.1
-ruff==0.4.9
+-r requirements-dev.txt
 
+homeassistant==2024.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+colorlog==6.8.2
+ffmpeg==1.4
+mypy-dev==1.11.0a6
+pre-commit==3.7.1
+pydantic==1.10.15
+ruff==0.4.9


### PR DESCRIPTION
Missing requirements are needed to allow VScode debugging
