### PR TITLE
fix: VScode debugging part2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Python Debugger: Launch Home Assistant",
       "type": "debugpy",
       "request": "launch",
-      "program": "/home/vscode/.local/bin/hass",
+      "program": "/usr/local/bin/hass",
       "args": ["--config", "config", "--debug"],
       "console": "integratedTerminal",
       "justMyCode": false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 colorlog==6.8.2
 ffmpeg==1.4
 mypy-dev==1.11.0a6
+numpy==2.0.0
 pre-commit==3.7.1
 pydantic==1.10.15
 ruff==0.4.9


### PR DESCRIPTION
Please select "**Dev Containers: Rebuild Container Without Cache**"  from VScode command palette when rebuilding the devcontainer.
