### PR TITLE
chore: bump midealocal v1.3.0

### DIFF
--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
   "requirements": ["pycryptodome", "midea-local==1.3.0"],
-  "version": "v0.5.1"
+  "version": "v0.5.0"
 }

--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
-  "requirements": ["pycryptodome", "midea-local==1.2.0"],
-  "version": "v0.5.0"
+  "requirements": ["pycryptodome", "midea-local==1.3.0"],
+  "version": "v0.5.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pycryptodome==3.20.0
-midea-local==1.2.0
+midea-local==1.3.0


### PR DESCRIPTION
# PR Description
midealocal v1.3.0 only used for mainfest v0.5.1 new release, to fix urgent error, so directly update this file with both version content, not split to both PRs with more steps.
I think it should be acceptable, please help to review, then we can quickly release new version.

## Reason & Detail

## Related issue

fix #215 , #221 , #207 ,  #191

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
