### PR TITLE
fix(flow): get capabilities should not happen during flow

### DIFF
--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -450,7 +450,7 @@ class MideaLanConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 subtype=0,
                 attributes={},
             )
-            if dm.connect(refresh_status=False):
+            if dm.connect(refresh_status=False, get_capabilities=False):
                 dm.close_socket()
                 return value
             # return debug log with failed key
@@ -681,7 +681,7 @@ class MideaLanConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 subtype=0,
                 attributes={},
             )
-            if dm.connect(refresh_status=False):
+            if dm.connect(refresh_status=False, get_capabilities=False):
                 dm.close_socket()
                 data = {
                     CONF_NAME: user_input[CONF_NAME],


### PR DESCRIPTION
# PR Description

## Reason & Detail

Device connect was called in a mock device when it shouldn't.

## Related issue
It should fix raise of get capabilities on flow and get_keys.

fixes #221 #219 

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
