### PR TITLE
fix: main feature entity name

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -197,9 +197,15 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
     0x40: {
         "name": "Integrated Ceiling Fan",
         "entities": {
-            "fan": {"type": Platform.FAN, "icon": "mdi:fan", "default": True},
+            "fan": {
+                "type": Platform.FAN,
+                "has_entity_name": True,
+                "icon": "mdi:fan",
+                "default": True,
+            },
             X40Attributes.current_temperature: {
                 "type": Platform.SENSOR,
+                "has_entity_name": True,
                 "name": "Current Temperature",
                 "device_class": SensorDeviceClass.TEMPERATURE,
                 "unit": UnitOfTemperature.CELSIUS,
@@ -207,16 +213,22 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             },
             X40Attributes.light: {
                 "type": Platform.SWITCH,
+                "has_entity_name": True,
+                "translation_key": "light",
                 "name": "Light",
                 "icon": "mdi:lightbulb",
             },
             X40Attributes.ventilation: {
                 "type": Platform.SWITCH,
+                "has_entity_name": True,
+                "translation_key": "ventilation",
                 "name": "Ventilation",
                 "icon": "mdi:air-filter",
             },
             X40Attributes.smelly_sensor: {
                 "type": Platform.SWITCH,
+                "has_entity_name": True,
+                "translation_key": "smelly_sensor",
                 "name": "Smelly Sensor",
                 "icon": "mdi:scent",
             },

--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -38,7 +38,11 @@ class MideaEntity(Entity):
 
         self._attr_translation_key = self._config.get("translation_key")
         self._attr_has_entity_name = self._config.get("has_entity_name", False)
-        if not self.has_entity_name:  # old behavior
+        if self.has_entity_name:
+            if self._config.get('name') is None:
+                self._attr_name = None
+        else:
+            # old behavior
             self._attr_name = (
                 f"{self._device_name} {self._config.get('name')}"
                 if "name" in self._config

--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -39,7 +39,7 @@ class MideaEntity(Entity):
         self._attr_translation_key = self._config.get("translation_key")
         self._attr_has_entity_name = self._config.get("has_entity_name", False)
         if self.has_entity_name:
-            if self._config.get('name') is None:
+            if self._config.get("name") is None:
                 self._attr_name = None
         else:
             # old behavior

--- a/custom_components/midea_ac_lan/translations/de.json
+++ b/custom_components/midea_ac_lan/translations/de.json
@@ -97,8 +97,17 @@
       }
     },
     "switch": {
+      "light": {
+        "name": "Light"
+      },
       "power": {
         "name": "Power"
+      },
+      "smelly_sensor": {
+        "name": "Smelly Sensor"
+      },
+      "ventilation": {
+        "name": "Ventilation"
       }
     }
   },

--- a/custom_components/midea_ac_lan/translations/en.json
+++ b/custom_components/midea_ac_lan/translations/en.json
@@ -97,8 +97,17 @@
       }
     },
     "switch": {
+      "light": {
+        "name": "Light"
+      },
       "power": {
         "name": "Power"
+      },
+      "smelly_sensor": {
+        "name": "Smelly Sensor"
+      },
+      "ventilation": {
+        "name": "Ventilation"
       }
     }
   },

--- a/custom_components/midea_ac_lan/translations/fr.json
+++ b/custom_components/midea_ac_lan/translations/fr.json
@@ -97,8 +97,17 @@
       }
     },
     "switch": {
+      "light": {
+        "name": "Light"
+      },
       "power": {
         "name": "Power"
+      },
+      "smelly_sensor": {
+        "name": "Smelly Sensor"
+      },
+      "ventilation": {
+        "name": "Ventilation"
       }
     }
   },

--- a/custom_components/midea_ac_lan/translations/hu.json
+++ b/custom_components/midea_ac_lan/translations/hu.json
@@ -97,8 +97,17 @@
       }
     },
     "switch": {
+      "light": {
+        "name": "Light"
+      },
       "power": {
         "name": "Power"
+      },
+      "smelly_sensor": {
+        "name": "Smelly Sensor"
+      },
+      "ventilation": {
+        "name": "Ventilation"
       }
     }
   },

--- a/custom_components/midea_ac_lan/translations/ru.json
+++ b/custom_components/midea_ac_lan/translations/ru.json
@@ -97,8 +97,17 @@
       }
     },
     "switch": {
+      "light": {
+        "name": "Light"
+      },
       "power": {
         "name": "Power"
+      },
+      "smelly_sensor": {
+        "name": "Smelly Sensor"
+      },
+      "ventilation": {
+        "name": "Ventilation"
       }
     }
   },

--- a/custom_components/midea_ac_lan/translations/sk.json
+++ b/custom_components/midea_ac_lan/translations/sk.json
@@ -97,8 +97,17 @@
       }
     },
     "switch": {
+      "light": {
+        "name": "Light"
+      },
       "power": {
         "name": "Power"
+      },
+      "smelly_sensor": {
+        "name": "Smelly Sensor"
+      },
+      "ventilation": {
+        "name": "Ventilation"
       }
     }
   },

--- a/custom_components/midea_ac_lan/translations/zh-Hans.json
+++ b/custom_components/midea_ac_lan/translations/zh-Hans.json
@@ -97,8 +97,17 @@
       }
     },
     "switch": {
+      "light": {
+        "name": "灯光"
+      },
       "power": {
         "name": "电源开关"
+      },
+      "smelly_sensor": {
+        "name": "异味感应"
+      },
+      "ventilation": {
+        "name": "换气"
       }
     }
   },


### PR DESCRIPTION
# PR Description

- Fix the naming of a device **main** feature, use `"has_entity_name": True` and `"name": None`
- Add some entity name to `40` device

## Reason & Detail

The previous implementation had some problems.

## Related issue

#174
