### PR TITLE
fix: add missing logger

### DIFF
--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
-  "requirements": ["pycryptodome", "midea-local==2.1.1"],
   "loggers": ["midealocal"],
+  "requirements": ["pycryptodome", "midea-local==2.1.1"],
   "version": "v0.5.4"
 }

--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -9,5 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
   "requirements": ["pycryptodome", "midea-local==2.1.1"],
+  "loggers": ["midealocal"],
   "version": "v0.5.4"
 }


### PR DESCRIPTION
Add missing logger to the manifest so when debugging is enabled from the UI is enabled also for the library and not only for the integration.

