### PR TITLE
fix: only protocol v3 device should run authenticate in config_flow

### DIFF
--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -702,7 +702,7 @@ class MideaLanConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             )
             if dm.connect():
                 try:
-                    if user_input[CONF_PROTOCOL] != ProtocolVersion.V3:
+                    if user_input[CONF_PROTOCOL] == ProtocolVersion.V3:
                         dm.authenticate()
                 except SocketException:
                     _LOGGER.exception("Socket closed.")


### PR DESCRIPTION
# PR Description
the should be an error process for device authenticate

## Reason & Detail

## Related issue


<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
