### PR TITLE
fix: Add MideaACFreshAirFan feature turn_on and turn_off

### DIFF
--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -63,11 +63,10 @@ async def async_setup_entry(
     async_add_entities(devs)
 
 
-FAN_FEATURE_TURN_ON_OFF: FanEntityFeature = (
-    (FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF)
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8)
-    else FanEntityFeature(0)
-)
+if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
+    FAN_FEATURE_TURN_ON_OFF = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+else:
+    FAN_FEATURE_TURN_ON_OFF = FanEntityFeature(0)
 
 
 class MideaFan(MideaEntity, FanEntity):

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -184,7 +184,8 @@ class MideaACFreshAirFan(MideaFan):
         """Midea AC Fresh Air Fan entity init."""
         super().__init__(device, entity_key)
         self._attr_supported_features = (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
+            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE |
+            FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
         )
         self._attr_speed_count = 100
 

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -62,9 +62,9 @@ async def async_setup_entry(
 
 
 # HA version >= 2024,8 support TURN_ON | TURN_OFF,for future changes, ref PR #285
-try:
+if hasattr(FanEntityFeature, "TURN_ON") and hasattr(FanEntityFeature, "TURN_OFF"):
     FAN_FEATURE_TURN_ON_OFF = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
-except AttributeError:
+else:
     FAN_FEATURE_TURN_ON_OFF = FanEntityFeature(0)
 
 

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -5,7 +5,13 @@ from typing import Any, cast
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEVICE_ID, CONF_SWITCHES, Platform
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_SWITCHES,
+    MAJOR_VERSION,
+    MINOR_VERSION,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from midealocal.device import DeviceType
@@ -57,8 +63,17 @@ async def async_setup_entry(
     async_add_entities(devs)
 
 
+FAN_FEATURE_TURN_ON_OFF: FanEntityFeature = (
+    (FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF)
+    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8)
+    else FanEntityFeature(0)
+)
+
+
 class MideaFan(MideaEntity, FanEntity):
     """Midea Fan Entries Base Class."""
+
+    _enable_turn_on_off_backwards_compatibility = False  # 2024.8~2025.1
 
     @property
     def preset_modes(self) -> list[str] | None:
@@ -137,6 +152,7 @@ class MideaFAFan(MideaFan):
             FanEntityFeature.SET_SPEED
             | FanEntityFeature.OSCILLATE
             | FanEntityFeature.PRESET_MODE
+            | FAN_FEATURE_TURN_ON_OFF
         )
         self._attr_speed_count = self._device.speed_count
 
@@ -160,7 +176,9 @@ class MideaB6Fan(MideaFan):
         """Midea B6 Fan entity init."""
         super().__init__(device, entity_key)
         self._attr_supported_features = (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+            | FAN_FEATURE_TURN_ON_OFF
         )
         self._attr_speed_count = self._device.speed_count
 
@@ -186,8 +204,7 @@ class MideaACFreshAirFan(MideaFan):
         self._attr_supported_features = (
             FanEntityFeature.SET_SPEED
             | FanEntityFeature.PRESET_MODE
-            | FanEntityFeature.TURN_ON
-            | FanEntityFeature.TURN_OFF
+            | FAN_FEATURE_TURN_ON_OFF
         )
         self._attr_speed_count = 100
 
@@ -246,7 +263,9 @@ class MideaCEFan(MideaFan):
         """Midea CE Fan entity init."""
         super().__init__(device, entity_key)
         self._attr_supported_features = (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+            | FAN_FEATURE_TURN_ON_OFF
         )
         self._attr_speed_count = self._device.speed_count
 
@@ -273,7 +292,9 @@ class MideaX40Fan(MideaFan):
         """Midea X40 Fan entity init."""
         super().__init__(device, entity_key)
         self._attr_supported_features = (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.OSCILLATE
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.OSCILLATE
+            | FAN_FEATURE_TURN_ON_OFF
         )
         self._attr_speed_count = 2
 

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -184,8 +184,10 @@ class MideaACFreshAirFan(MideaFan):
         """Midea AC Fresh Air Fan entity init."""
         super().__init__(device, entity_key)
         self._attr_supported_features = (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE |
-            FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.TURN_ON
+            | FanEntityFeature.TURN_OFF
         )
         self._attr_speed_count = 100
 

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -8,8 +8,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_SWITCHES,
-    MAJOR_VERSION,
-    MINOR_VERSION,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -63,9 +61,10 @@ async def async_setup_entry(
     async_add_entities(devs)
 
 
-if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
+# HA version >= 2024,8 support TURN_ON | TURN_OFF, add comments for future changes, ref PR #285
+try:
     FAN_FEATURE_TURN_ON_OFF = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
-else:
+except AttributeError:
     FAN_FEATURE_TURN_ON_OFF = FanEntityFeature(0)
 
 

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -63,7 +63,7 @@ async def async_setup_entry(
 
 # HA version >= 2024,8 support TURN_ON | TURN_OFF,for future changes, ref PR #285
 try:
-    FAN_FEATURE_TURN_ON_OFF = FanEntityFeature['TURN_ON'] | FanEntityFeature['TURN_OFF']
+    FAN_FEATURE_TURN_ON_OFF = FanEntityFeature["TURN_ON"] | FanEntityFeature["TURN_OFF"]
 except KeyError:
     FAN_FEATURE_TURN_ON_OFF = FanEntityFeature(0)
 

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -61,7 +61,7 @@ async def async_setup_entry(
     async_add_entities(devs)
 
 
-# HA version >= 2024,8 support TURN_ON | TURN_OFF, add comments for future changes, ref PR #285
+# HA version >= 2024,8 support TURN_ON | TURN_OFF,for future changes, ref PR #285
 try:
     FAN_FEATURE_TURN_ON_OFF = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
 except AttributeError:

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -62,9 +62,9 @@ async def async_setup_entry(
 
 
 # HA version >= 2024,8 support TURN_ON | TURN_OFF,for future changes, ref PR #285
-if hasattr(FanEntityFeature, "TURN_ON") and hasattr(FanEntityFeature, "TURN_OFF"):
-    FAN_FEATURE_TURN_ON_OFF = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
-else:
+try:
+    FAN_FEATURE_TURN_ON_OFF = FanEntityFeature['TURN_ON'] | FanEntityFeature['TURN_OFF']
+except KeyError:
     FAN_FEATURE_TURN_ON_OFF = FanEntityFeature(0)
 
 


### PR DESCRIPTION
# PR Description

SSIA

https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/

## Reason & Detail

from the current HA (2024.8.2) logs

```log
2024-08-16 20:31:49.478 WARNING (MainThread) [homeassistant.components.fan] Entity midea_ac_lan.153931628304529_fresh_air (<class 'custom_components.midea_ac_lan.fan.MideaACFreshAirFan'>) does not set FanEntityFeature.TURN_OFF but implements the turn_off method. Please create a bug report at https://github.com/wuwentao/midea_ac_lan/issues
2024-08-16 20:31:49.478 WARNING (MainThread) [homeassistant.components.fan] Entity midea_ac_lan.153931628304529_fresh_air (<class 'custom_components.midea_ac_lan.fan.MideaACFreshAirFan'>) does not set FanEntityFeature.TURN_ON but implements the turn_on method. Please create a bug report at https://github.com/wuwentao/midea_ac_lan/issues
``` 

## Related issue

none

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
