### PR TITLE
fix: water_heater: do not set target_temperature_high and target_temperature_low

### DIFF
--- a/custom_components/midea_ac_lan/water_heater.py
+++ b/custom_components/midea_ac_lan/water_heater.py
@@ -119,16 +119,6 @@ class MideaWaterHeater(MideaEntity, WaterHeaterEntity):
         raise NotImplementedError
 
     @property
-    def target_temperature_low(self) -> float:
-        """Midea Water Heater target temperature low."""
-        return self.min_temp
-
-    @property
-    def target_temperature_high(self) -> float:
-        """Midea Water Heater target temperature high."""
-        return self.max_temp
-
-    @property
     def precision(self) -> float:
         """Midea Water Heater precision."""
         return float(PRECISION_WHOLE)


### PR DESCRIPTION
# PR Description

## Reason & Detail
these values are for target temperature range. It is obviously incorrect to set these values to min_temp and max_temp. Since we can not get/set the device's target temperature range, we should not set these values.
## Related issue

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
