### PR TITLE
build: cleanup requirements

### DIFF
--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
   "loggers": ["midealocal"],
-  "requirements": ["pycryptodome", "midea-local==6.0.3"],
+  "requirements": ["midea-local==6.0.3"],
   "version": "v0.6.5"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pycryptodome==3.20.0
 midea-local==6.0.3


### PR DESCRIPTION
`pycryptodome` is needed by the library, not the integration
