### PR TITLE
fix(ac): update AC device min temperature from 17 to 16

### DIFF
--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -58,7 +58,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 TEMPERATURE_MAX = 30
-TEMPERATURE_MIN = 17
+TEMPERATURE_MIN = 16
 
 FAN_SILENT = "silent"
 FAN_FULL_SPEED = "full"


### PR DESCRIPTION
# PR Description

AC device temperature range should be 16-30 and not 17-30

## Reason & Detail

## Related issue

fix #396 

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
