### PR TITLE
fix(e3): e3 water heater set power cause current operation unknown

### DIFF
--- a/custom_components/midea_ac_lan/water_heater.py
+++ b/custom_components/midea_ac_lan/water_heater.py
@@ -249,6 +249,13 @@ class MideaE3WaterHeater(MideaWaterHeater):
             PRECISION_HALVES if self._device.precision_halves else PRECISION_WHOLE,
         )
 
+    @property
+    def current_operation(self) -> str:
+        """Midea E3 Water Heater current operation."""
+        return str(
+            STATE_ON if self._device.get_attribute("power") else STATE_OFF,
+        )
+
 
 class MideaC3WaterHeater(MideaWaterHeater):
     """Midea C3 Water Heater Entries."""


### PR DESCRIPTION
# PR Description
fix e3 water heater set power cause current operation unknown

## Reason & Detail
fix e3 water heater set power cause current operation unknown

## Related issue

fix #413 

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
