### PR TITLE
chore(main): bump midea-local to v6.1.0

### DIFF
--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
   "loggers": ["midealocal"],
-  "requirements": ["midea-local==6.0.3"],
+  "requirements": ["midea-local==6.1.0"],
   "version": "v0.6.5"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-midea-local==6.0.3
+midea-local==6.1.0


### PR DESCRIPTION
# PR Description
bump midea-local to v6.1.0

## Reason & Detail
bump midea-local to v6.1.0

## Related issue

fix #X

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
