### PR TITLE
chore(mypy): switch mypy-dev to mypy release

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 colorlog==6.8.2
 ffmpeg==1.4
-mypy-dev==1.11.0a6
+mypy==1.15.0
 mutagen==1.47.0
 numpy==2.0.0
 pre-commit==3.7.1


### PR DESCRIPTION
# PR Description
switch mypy-dev to mypy release as dev version not available now


## Reason & Detail
switch mypy-dev to mypy release as dev version not available now

```
Collecting ffmpeg==1.4 (from -r /home/runner/work/midea_ac_lan/midea_ac_lan/requirements-dev.txt (line 2))
  Downloading ffmpeg-1.4.tar.gz (5.1 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
ERROR: Could not find a version that satisfies the requirement mypy-dev==1.11.0a6 (from versions: 1.9.0b1, 1.10.0b1, 1.11.0b1, 1.12.0b1, 1.13.0a2, 1.14.0a1, 1.14.0a2, 1.14.0a3, 1.14.0a4, 1.14.0a5, 1.14.0a6, 1.14.0a7, 1.15.0a1, 1.15.0a2, 1.16.0a1, 1.16.0a2)
ERROR: No matching distribution found for mypy-dev==1.11.0a6
Error: Process completed with exit code 1.
```

## Related issue

fix #X

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
