### PR TITLE
fix(device): water heater temperature should be float

### DIFF
--- a/custom_components/midea_ac_lan/water_heater.py
+++ b/custom_components/midea_ac_lan/water_heater.py
@@ -106,7 +106,7 @@ class MideaWaterHeater(MideaEntity, WaterHeaterEntity):
         """Midea Water Heater extra state attributes."""
         attrs: dict[str, Any] = self._device.attributes
         if hasattr(self._device, "temperature_step"):
-            attrs["target_temp_step"] = self._device.temperature_step
+            attrs["target_temperature_step"] = self._device.temperature_step
         return attrs
 
     @property
@@ -155,7 +155,8 @@ class MideaWaterHeater(MideaEntity, WaterHeaterEntity):
         """Midea Water Heater set temperature."""
         if ATTR_TEMPERATURE not in kwargs:
             return
-        temperature = int(kwargs[ATTR_TEMPERATURE])
+        # input target_temperature should be float
+        temperature = float(kwargs[ATTR_TEMPERATURE])
         self._device.set_attribute("target_temperature", temperature)
 
     def set_operation_mode(self, operation_mode: str) -> None:
@@ -292,7 +293,7 @@ class MideaC3WaterHeater(MideaWaterHeater):
         """Midea C3 Water Heater set temperature."""
         if ATTR_TEMPERATURE not in kwargs:
             return
-        temperature = int(kwargs[ATTR_TEMPERATURE])
+        temperature = float(kwargs[ATTR_TEMPERATURE])
         self._device.set_attribute(C3Attributes.dhw_target_temp, temperature)
 
     @property
@@ -375,7 +376,7 @@ class MideaE6WaterHeater(MideaWaterHeater):
         """Midea E6 Water Heater set temperature."""
         if ATTR_TEMPERATURE not in kwargs:
             return
-        temperature = int(kwargs[ATTR_TEMPERATURE])
+        temperature = float(kwargs[ATTR_TEMPERATURE])
         self._device.set_attribute(self._target_temperature_attr, temperature)
 
     @property


### PR DESCRIPTION
# PR Description
issue exist for https://github.com/wuwentao/midea_ac_lan/issues/517

it impact to device type E2/E3/E6/C3/CD
related midea-local PR:
https://github.com/midea-lan/midea-local/pull/363
https://github.com/midea-lan/midea-local/pull/361
https://github.com/midea-lan/midea-local/pull/359
https://github.com/midea-lan/midea-local/pull/358
https://github.com/midea-lan/midea-local/pull/357

## Reason & Detail
temperature should be float type and NOT int, as some device step is 0.5, default step can be  1.0

## Related issue

fix #517 

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
