### PR TITLE
fix(device): prevent crash if socket is None during unload

### DIFF
--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -273,7 +273,10 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     if device_id is not None:
         dm = hass.data[DOMAIN][DEVICES].get(device_id)
         if dm is not None:
-            dm.close()
+            try:
+                dm.close()
+            except Exception:
+                _LOGGER.warning("Failed to close Midea socket cleanly, skipping.")
         hass.data[DOMAIN][DEVICES].pop(device_id)
     # Forward the unloading of an entry to platforms
     await hass.config_entries.async_unload_platforms(config_entry, ALL_PLATFORM)


### PR DESCRIPTION
## Problem

Unloading a Midea LAN device (like the MF200 washer) sometimes calls `dm.close()`, which blows up with:

AttributeError: 'NoneType' object has no attribute 'close'

Turns out, the `_socket` isn't always initialized, so HA chokes, labels the config entry as `FAILED_UNLOAD`, and refuses to reload it ever again. This bricks `reload_config_entry` and any automation relying on it, until reboot.

## Fix

Wrap `dm.close()` in a `try/except` block so the integration can quietly move on with its life if the socket’s not there.

## Why it matters

- Prevents reloads from silently failing
- Keeps the integration usable without needing restarts
- Allows automation-driven reloads to work as intended

## Tested on

- MF200 Washer (v3 protocol)
- HAOS 2025.7.3