### PR TITLE
fix(ac): fix ac device custom fan_mode value translate

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -402,6 +402,7 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             "climate": {
                 "type": Platform.CLIMATE,
                 "has_entity_name": True,
+                "translation_key": "climate_key",
                 "icon": "mdi:air-conditioner",
                 "default": True,
             },

--- a/custom_components/midea_ac_lan/translations/en.json
+++ b/custom_components/midea_ac_lan/translations/en.json
@@ -214,6 +214,16 @@
       },
       "climate_zone2": {
         "name": "Zone2 Thermostat"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "Silent",
+              "full": "Full"
+            }
+          }
+        }
       }
     },
     "fan": {

--- a/custom_components/midea_ac_lan/translations/zh-Hans.json
+++ b/custom_components/midea_ac_lan/translations/zh-Hans.json
@@ -214,6 +214,16 @@
       },
       "climate_zone2": {
         "name": "区域2恒温器"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "静音",
+              "full": "全速"
+            }
+          }
+        }
       }
     },
     "fan": {


### PR DESCRIPTION
# PR Description
fix ac device custom fan_mode value translate

## Reason & Detail
define climate with a translate_key `climate_key` and add translate file to support it.

## Related issue

fix #483 

<!--
please change X to issue id, it will auto close this issue once PR closed
Example:
fix #1
it will auto close issue #1 once PR closed
-->
