### PR TITLE
Update Dockerfile for conditional mirror configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,22 +20,18 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 # They would conflict with our requirements.txt
 RUN pipx uninstall mypy
 
-# .bashrc or .zshrc add mirror site:
-# export APT_MIRROR_DOMAIN="mirrors.tuna.tsinghua.edu.cn"
-# --- BEGIN: APT China Mirror Configuration ---
-# First, ensure apt's sources.list is initialized
-RUN cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
+RUN if [ -n "${APT_MIRROR_DOMAIN}" ] && [ "${APT_MIRROR_DOMAIN}" != "deb.debian.org" ]; then \
+    cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
     sed -i "s|deb.debian.org|${APT_MIRROR_DOMAIN}|g" /etc/apt/sources.list && \
-    sed -i "s|security.debian.org|${APT_MIRROR_DOMAIN}|g" /etc/apt/sources.list && \
-    apt-get clean all && rm -rf /var/lib/apt/lists/* && apt-get update
+    sed -i "s|security.debian.org|${APT_MIRROR_DOMAIN}|g" /etc/apt/sources.list; \
+fi && \
+apt-get clean all && rm -rf /var/lib/apt/lists/* && apt-get update
 
-# .bashrc or .zshrc add mirror site:
-# export PIP_MIRROR_DOMAIN="pypi.tuna.tsinghua.edu.cn"
-# --- BEGIN: PIP China Mirror Configuration ---
-RUN echo "[global]" > /etc/pip.conf && \
+RUN if [ -n "${PIP_MIRROR_DOMAIN}" ] && [ "${PIP_MIRROR_DOMAIN}" != "pypi.org" ]; then \
+    echo "[global]" > /etc/pip.conf && \
     echo "index-url = https://${PIP_MIRROR_DOMAIN}/simple" >> /etc/pip.conf && \
-    echo "trusted-host = ${PIP_MIRROR_DOMAIN}" >> /etc/pip.conf
-# --- END: PIP Mirror Configuration ---
+    echo "trusted-host = ${PIP_MIRROR_DOMAIN}" >> /etc/pip.conf; \
+fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,8 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 # They would conflict with our requirements.txt
 RUN pipx uninstall mypy
 
+RUN rm -f /etc/apt/sources.list.d/yarn.list
+
 RUN if [ -n "${APT_MIRROR_DOMAIN}" ] && [ "${APT_MIRROR_DOMAIN}" != "deb.debian.org" ]; then \
     cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
     sed -i "s|deb.debian.org|${APT_MIRROR_DOMAIN}|g" /etc/apt/sources.list && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
 # Declare the build argument VARIANT in the global scope, can be overwrite with devcontainer.json build args
 ARG VARIANT=3.12
-FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}-bullseye
+FROM mcr.microsoft.com/devcontainers/python:${VARIANT}-bullseye
 
 # define apt default source
 ARG APT_MIRROR_DOMAIN="deb.debian.org"


### PR DESCRIPTION
Refactor APT and PIP mirror configuration to check for environment variables before setting them.  Helps users contribute from a variety of countries with a simple dev container clone.

# PR Description

Fix Dockerfile mirror configuration to work outside China Mainland

## Reason & Detail

The `APT_MIRROR_DOMAIN` and `PIP_MIRROR_DOMAIN` build args have defaults defined in both the Dockerfile and `devcontainer.json`, but the dev containers CLI passes them as empty strings when they aren't set in the local environment, overriding the Dockerfile `ARG` defaults. This breaks the recommended "Clone in Container Volume" workflow for anyone outside China, since the `sed` commands produce malformed URLs like `http:/debian` instead of `http://deb.debian.org/debian`.

The fix wraps both the APT and pip mirror configurations in a guard that skips the substitution when the build arg is empty or already the default, making the Dockerfile resilient regardless of how build args are passed.
