### PR TITLE
Guard state updates during HA shutdown and stop forcing entity_id

### DIFF
--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -243,14 +243,7 @@ class MideaClimate(MideaEntity, ClimateEntity):
 
     def update_state(self, status: Any) -> None:  # noqa: ANN401, ARG002
         """Midea Climate update state."""
-        if not self.hass:
-            _LOGGER.warning(
-                "Climate update_state skipped for %s [%s]: HASS is None",
-                self.name,
-                type(self),
-            )
-            return
-        self.schedule_update_ha_state()
+        self._schedule_update_ha_state_safely("Climate")
 
 
 class MideaACClimate(MideaClimate):

--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -133,14 +133,7 @@ class MideaFan(MideaEntity, FanEntity):
 
     def update_state(self, status: Any) -> None:  # noqa: ANN401, ARG002
         """Midea Fan update state."""
-        if not self.hass:
-            _LOGGER.warning(
-                "Fan update_state skipped for %s [%s]: HASS is None",
-                self.name,
-                type(self),
-            )
-            return
-        self.schedule_update_ha_state()
+        self._schedule_update_ha_state_safely("Fan")
 
 
 class MideaFAFan(MideaFan):

--- a/custom_components/midea_ac_lan/humidifier.py
+++ b/custom_components/midea_ac_lan/humidifier.py
@@ -102,14 +102,7 @@ class MideaHumidifier(MideaEntity, HumidifierEntity):
 
     def update_state(self, status: Any) -> None:  # noqa: ANN401, ARG002
         """Midea Humidifier update state."""
-        if not self.hass:
-            _LOGGER.warning(
-                "Humidifier update_state skipped for %s [%s]: HASS is None",
-                self.name,
-                type(self),
-            )
-            return
-        self.schedule_update_ha_state()
+        self._schedule_update_ha_state_safely("Humidifier")
 
 
 class MideaA1Humidifier(MideaHumidifier):

--- a/custom_components/midea_ac_lan/light.py
+++ b/custom_components/midea_ac_lan/light.py
@@ -174,11 +174,4 @@ class MideaLight(MideaEntity, LightEntity):
 
     def update_state(self, status: Any) -> None:  # noqa: ANN401,ARG002
         """Midea Light update state."""
-        if not self.hass:
-            _LOGGER.warning(
-                "Light update_state skipped for %s [%s]: HASS is None",
-                self.name,
-                type(self),
-            )
-            return
-        self.schedule_update_ha_state()
+        self._schedule_update_ha_state_safely("Light")

--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -124,6 +124,7 @@ class MideaEntity(Entity):
 
         Raises:
             RuntimeError: Re-raises unexpected scheduling errors.
+
         """
         if not self.hass:
             _LOGGER.warning(

--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -34,7 +34,6 @@ class MideaEntity(Entity):
         )[entity_key]
         self._entity_key = entity_key
         self._unique_id = f"{DOMAIN}.{self._device.device_id}_{entity_key}"
-        self.entity_id = self._unique_id
         self._device_name = self._device.name
 
         # HA language setting:
@@ -120,25 +119,56 @@ class MideaEntity(Entity):
         return cast("str", self._config.get("icon"))
 
     @callback
-    def update_state(self, status: Any) -> None:  # noqa: ANN401
-        """Update entity state."""
+    def _schedule_update_ha_state_safely(self, source: str) -> None:
+        """Schedule an HA state update unless HA is shutting down.
+
+        Raises:
+            RuntimeError: Re-raises unexpected scheduling errors.
+        """
         if not self.hass:
             _LOGGER.warning(
-                "MideaEntity update_state for %s [%s] with status %s: HASS is None",
+                "%s update_state skipped for %s [%s]: HASS is None",
+                source,
                 self.name,
                 type(self),
-                status,
             )
             return
 
         if self.hass.is_stopping:
             _LOGGER.debug(
-                "MideaEntity update_state for %s [%s] with status %s: HASS is stopping",
+                "%s update_state skipped for %s [%s]: HASS is stopping",
+                source,
                 self.name,
                 type(self),
-                status,
             )
             return
 
-        if self._entity_key in status or "available" in status:
+        loop = getattr(self.hass, "loop", None)
+        if loop is not None and loop.is_closed():
+            _LOGGER.debug(
+                "%s update_state skipped for %s [%s]: HASS event loop is closed",
+                source,
+                self.name,
+                type(self),
+            )
+            return
+
+        try:
             self.schedule_update_ha_state()
+        except RuntimeError as err:
+            if "Event loop is closed" in str(err):
+                _LOGGER.debug(
+                    "%s update_state skipped for %s [%s]: %s",
+                    source,
+                    self.name,
+                    type(self),
+                    err,
+                )
+                return
+            raise
+
+    @callback
+    def update_state(self, status: Any) -> None:  # noqa: ANN401
+        """Update entity state."""
+        if self._entity_key in status or "available" in status:
+            self._schedule_update_ha_state_safely("MideaEntity")

--- a/custom_components/midea_ac_lan/water_heater.py
+++ b/custom_components/midea_ac_lan/water_heater.py
@@ -188,14 +188,7 @@ class MideaWaterHeater(MideaEntity, WaterHeaterEntity):
 
     def update_state(self, status: Any) -> None:  # noqa: ANN401, ARG002
         """Midea Water Heater update state."""
-        if not self.hass:
-            _LOGGER.warning(
-                "Water update_state skipped for %s [%s]: HASS is None",
-                self.name,
-                type(self),
-            )
-            return
-        self.schedule_update_ha_state()
+        self._schedule_update_ha_state_safely("Water heater")
 
 
 class MideaE2WaterHeater(MideaWaterHeater):


### PR DESCRIPTION
# PR Description

## Reason & Detail

This PR fixes two Home Assistant compatibility issues observed with HA Core 2026.5.1 and `midea_ac_lan` v0.6.11.

First, `midea-local` invokes update callbacks from background device threads. During Home Assistant shutdown or restart, those callbacks can still run after HA has started stopping, or after the asyncio event loop has already closed. Calling `schedule_update_ha_state()` in that window raises:

```text
RuntimeError: Event loop is closed
```

The base entity already checked `hass.is_stopping`, but direct `schedule_update_ha_state()` calls still existed in several overridden `update_state()` methods. There was also still a race window where the loop could close between the guard and the scheduling call.

This PR:

- Adds a shared `MideaEntity._schedule_update_ha_state_safely()` helper.
- Skips scheduling when `hass` is missing, HA is stopping, or the HA loop is already closed.
- Catches only `RuntimeError: Event loop is closed` as a final race-condition safety net.
- Updates overridden `update_state()` methods in:
  - `climate.py`
  - `fan.py`
  - `humidifier.py`
  - `light.py`
  - `water_heater.py`
- Keeps other `RuntimeError` exceptions visible by re-raising them.

Second, `MideaEntity.__init__()` forced:

```python
self.entity_id = self._unique_id
```

Since `_unique_id` uses the integration domain prefix, this can create entity IDs under `midea_ac_lan.*` instead of the expected platform domains such as `climate.*`, `switch.*`, or `sensor.*`. Current HA versions warn about wrong-domain entity IDs, and this is expected to become incompatible in a future HA release.

This PR removes the forced entity ID assignment and lets Home Assistant assign the entity ID from the platform domain while keeping the existing `unique_id` stable.

Compatibility note: fresh setups should receive platform-domain entity IDs. Existing installations may already have entity registry entries created with the old wrong-domain IDs; those entries should still be matched by `unique_id`, but users may need to rename or repair previously stored entity IDs if Home Assistant keeps warning about older registry entries.

## Related issue

Relates to #798
Relates to #809
Fixes #813

## Local verification

```text
python -m py_compile custom_components/midea_ac_lan/midea_entity.py custom_components/midea_ac_lan/climate.py custom_components/midea_ac_lan/fan.py custom_components/midea_ac_lan/humidifier.py custom_components/midea_ac_lan/light.py custom_components/midea_ac_lan/water_heater.py
git diff --check
```

Both commands passed locally. `ruff` was not available in the local Python environment.

