### PR TITLE
Fix wrong-domain entity_ids (deprecated in HA 2027.5)

### DIFF
--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -310,7 +310,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     # 2 -> 3: rewrite entity_ids that wrongly used the integration domain
     # (e.g. "midea_ac_lan.123_humidity") to their proper platform domain
     # ("sensor.123_humidity"). Required for HA 2027.5 which rejects wrong-domain ids.
-    if config_entry.version == 2:
+    if config_entry.version == 2:  # noqa: PLR2004
         _LOGGER.debug("Migrating configuration from version 2")
 
         await _async_migrate_entity_ids(hass, config_entry)
@@ -360,7 +360,7 @@ async def _async_migrate_entity_ids(
         platform = key_to_platform.get(entity_key_str)
         if platform is None:
             _LOGGER.warning(
-                "midea_ac_lan: cannot migrate %s — unknown entity_key %s for device_type %s",
+                "midea_ac_lan: cannot migrate %s - unknown key %s for type %s",
                 entry.entity_id,
                 entity_key_str,
                 device_type,

--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -356,7 +356,7 @@ async def _async_migrate_entity_ids(
     for entry in er.async_entries_for_config_entry(registry, config_entry.entry_id):
         if not entry.entity_id.startswith(prefix):
             continue
-        entity_key_str = entry.entity_id[len(prefix):]
+        entity_key_str = entry.entity_id[len(prefix) :]
         platform = key_to_platform.get(entity_key_str)
         if platform is None:
             _LOGGER.warning(

--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
+import homeassistant.helpers.entity_registry as er
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -306,7 +307,83 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
         _LOGGER.debug("Migration to configuration version 2 successful")
 
+    # 2 -> 3: rewrite entity_ids that wrongly used the integration domain
+    # (e.g. "midea_ac_lan.123_humidity") to their proper platform domain
+    # ("sensor.123_humidity"). Required for HA 2027.5 which rejects wrong-domain ids.
+    if config_entry.version == 2:
+        _LOGGER.debug("Migrating configuration from version 2")
+
+        await _async_migrate_entity_ids(hass, config_entry)
+
+        if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 3):
+            hass.config_entries.async_update_entry(config_entry, version=3)
+        else:
+            config_entry.version = 3
+            hass.config_entries.async_update_entry(config_entry)
+
+        _LOGGER.debug("Migration to configuration version 3 successful")
+
     return True
+
+
+async def _async_migrate_entity_ids(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> None:
+    """Rewrite legacy `midea_ac_lan.*` entity_ids to their correct platform domain."""
+    if config_entry.data.get(CONF_TYPE) == CONF_ACCOUNT:
+        return
+
+    device_type = config_entry.data.get(CONF_TYPE) or 0xAC
+    device_id = config_entry.data.get(CONF_DEVICE_ID)
+    if device_id is None:
+        return
+
+    device_entities = cast(
+        "dict",
+        MIDEA_DEVICES.get(device_type, {}).get("entities", {}),
+    )
+    # Map "<entity_key as string>" -> Platform enum from MIDEA_DEVICES.
+    key_to_platform: dict[str, Any] = {}
+    for key, cfg in device_entities.items():
+        key_str = key.value if hasattr(key, "value") else str(key)
+        platform = cfg.get("type")
+        if platform is not None:
+            key_to_platform[key_str] = platform
+
+    prefix = f"{DOMAIN}.{device_id}_"
+    registry = er.async_get(hass)
+    for entry in er.async_entries_for_config_entry(registry, config_entry.entry_id):
+        if not entry.entity_id.startswith(prefix):
+            continue
+        entity_key_str = entry.entity_id[len(prefix):]
+        platform = key_to_platform.get(entity_key_str)
+        if platform is None:
+            _LOGGER.warning(
+                "midea_ac_lan: cannot migrate %s — unknown entity_key %s for device_type %s",
+                entry.entity_id,
+                entity_key_str,
+                device_type,
+            )
+            continue
+        new_entity_id = f"{platform.value}.{device_id}_{entity_key_str}"
+        if new_entity_id == entry.entity_id:
+            continue
+        try:
+            registry.async_update_entity(entry.entity_id, new_entity_id=new_entity_id)
+        except ValueError as err:
+            _LOGGER.warning(
+                "midea_ac_lan: could not rename %s -> %s: %s",
+                entry.entity_id,
+                new_entity_id,
+                err,
+            )
+        else:
+            _LOGGER.info(
+                "midea_ac_lan: migrated entity_id %s -> %s",
+                entry.entity_id,
+                new_entity_id,
+            )
 
 
 async def _async_migrate_device_identifiers(

--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -104,7 +104,7 @@ class MideaLanConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     ConfigFlow will manage the creation of entries from user input, discovery
     """
 
-    VERSION = 2
+    VERSION = 3
     MINOR_VERSION = 1
 
     def __init__(self) -> None:

--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -33,8 +33,12 @@ class MideaEntity(Entity):
             MIDEA_DEVICES[self._device.device_type]["entities"],
         )[entity_key]
         self._entity_key = entity_key
+        # NOTE: unique_id keeps its legacy "midea_ac_lan.<device_id>_<key>" shape
+        # so existing entity-registry entries (which key on unique_id) keep matching.
+        # entity_id is intentionally NOT set here anymore — HA derives it from the
+        # platform domain (sensor.*, humidifier.*, …). Old wrong-domain entity_ids
+        # are rewritten by the migration in __init__.async_migrate_entry (v2 -> v3).
         self._unique_id = f"{DOMAIN}.{self._device.device_id}_{entity_key}"
-        self.entity_id = self._unique_id
         self._device_name = self._device.name
 
         # HA language setting:


### PR DESCRIPTION
## Problem

`MideaEntity.__init__` sets `self.entity_id = self._unique_id`, where `_unique_id` is `f"{DOMAIN}.{self._device.device_id}_{entity_key}"`. That puts the integration domain (`midea_ac_lan.*`) into `entity_id`, overriding the platform domain (`sensor.*`, `humidifier.*`, `binary_sensor.*`, …).

Home Assistant has been logging this as a deprecation warning since 2024:

> custom integration 'midea_ac_lan' sets an entity ID with wrong domain […]

and **HA 2027.5 will reject it**. Affects every entity the integration creates.

## Fix

1. **`midea_entity.py`** — remove the `self.entity_id = self._unique_id` line. HA then derives `entity_id` from the platform domain, like every core integration. `unique_id` keeps its legacy `midea_ac_lan.<device_id>_<key>` shape so existing entity-registry rows keep matching (history / customizations / area assignments preserved).

2. **`__init__.py`** — add a v2 → v3 ConfigEntry migration (`_async_migrate_entity_ids`) that walks the entity registry for the entry, finds entries with `midea_ac_lan.<device_id>_*` ids, looks up the correct platform via `MIDEA_DEVICES[device_type]["entities"][key]["type"]`, and calls `er.async_update_entity(..., new_entity_id=...)` to rewrite them in place. Unknown keys are logged as a warning and skipped (not blocking).

3. **`config_flow.py`** — bump `VERSION` from 2 to 3 so the migration runs once on next start.

## Verification

Tested against a Midea dehumidifier with 9 entities across `sensor`, `binary_sensor`, `humidifier`, `switch`, `select`. After HA restart:

- ConfigEntry version 2 → 3
- All 9 registry rows renamed (e.g. `midea_ac_lan.<id>_humidity` → `sensor.<id>_humidity`)
- No more wrong-domain deprecation warnings in the log
- Automations and Lovelace cards that referenced the old ids broke as expected — users need to `grep -r midea_ac_lan\. config/` before upgrading and update references.

## Notes

- Account-type entries (`CONF_TYPE == CONF_ACCOUNT`) are skipped by the migration helper since they don't own device entities.
- The fallback `device_type = config_entry.data.get(CONF_TYPE) or 0xAC` matches the existing pattern elsewhere in the integration.
- Backwards-compat: keeping `unique_id` on the legacy shape was a deliberate choice — changing it would orphan every existing entity. Open to feedback if you'd prefer `unique_id` to also drop the `midea_ac_lan.` prefix, with a one-time `unique_id` migration alongside.