### PR TITLE
fix(manifest): remove "v" prefix from version field to satisfy HACS 2.0+

### DIFF
--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/wuwentao/midea_ac_lan/issues",
   "loggers": ["midealocal"],
   "requirements": ["midea-local==6.6.0"],
-  "version": "v0.6.11"
+  "version": "0.6.11"
 }


### PR DESCRIPTION
## Summary

Remove the `v` prefix from the `version` field in `custom_components/midea_ac_lan/manifest.json`.

HACS 2.0+ validates this field as strict [semver](https://semver.org/) (no prefix), so the current value `"v0.6.11"` causes installation to fail with:

> The version for this integration can not be used with HACS.

After this change the value is `"0.6.11"`. The git tag (`v0.6.11`) is unchanged — only `manifest.json` needs the prefix removed.

## How to reproduce

- HACS 2.0.5
- Home Assistant 2026.5.4
- Add this repo as a custom integration in HACS → click **Download** → error appears.

Older HACS (1.x) did not enforce this, which is likely why the issue hasn't surfaced before.

## Optional follow-up (not in this PR)

To prevent regressions, a CI step could assert that `manifest.json` `version` equals the release tag with any leading `v` stripped. Happy to send a separate PR for that if useful.

## Workaround for users until a new release

Download `midea_ac_lan.zip` from the [v0.6.11 release](https://github.com/wuwentao/midea_ac_lan/releases/tag/v0.6.11), extract into `<config>/custom_components/midea_ac_lan/`, and restart HA. HACS won't manage it (no auto-update), but the integration works normally.
