### PR TITLE
fix(ci): strip "v" prefix from release tag and validate semver in manifest version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,17 @@ jobs:
           # Extract the version from manifest.json
           manifest_version=$(grep -oP '(?<="version": ")[^"]*' custom_components/midea_ac_lan/manifest.json)
           echo "Manifest.json version: $manifest_version"
-          # Extract the release tag
+          # Validate semver format (no "v" prefix; HACS 2.0+ rejects "v"-prefixed versions)
+          if ! [[ "$manifest_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Error: manifest.json version ($manifest_version) is not valid semver. Must be X.Y.Z without a 'v' prefix."
+            exit 1
+          fi
+          # Extract the release tag, strip optional leading "v"
           release_tag="${GITHUB_REF#refs/tags/}"
-          echo "Release tag: $release_tag"
+          release_tag_stripped="${release_tag#v}"
+          echo "Release tag: $release_tag (stripped: $release_tag_stripped)"
           # Check if the versions match
-          if [ "$release_tag" != "$manifest_version" ]; then
+          if [ "$release_tag_stripped" != "$manifest_version" ]; then
             echo "Error: Release tag ($release_tag) does not match manifest.json version ($manifest_version)"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Follow-up to #819 (as requested by @wuwentao in [this comment](https://github.com/wuwentao/midea_ac_lan/pull/819#issuecomment-)).

This PR hardens the `manifest.json` version check in `release.yml` so that it both:

1. **Validates** `manifest.json` `version` against a strict semver regex — rejects any future regression that re-introduces a `v` prefix (or any other non-semver value).
2. **Strips** the optional leading `v` from `${GITHUB_REF#refs/tags/}` before comparing against the manifest version, so that a tag like `v0.6.12` continues to match a semver-compliant manifest value like `0.6.12`.

### Why this is needed

Before #819, `manifest.json` contained `"version": "v0.6.11"` because the original CI check compared the release tag (`v0.6.11`) literally to the manifest value. Now that the manifest is being changed to strict semver (`0.6.11`) for HACS 2.0+ compatibility, the literal comparison would break on the next release. This PR keeps the tag↔manifest invariant intact while enforcing semver going forward.

### Diff

```diff
-          # Extract the release tag
+          # Validate semver format (no "v" prefix; HACS 2.0+ rejects "v"-prefixed versions)
+          if ! [[ "$manifest_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Error: manifest.json version ($manifest_version) is not valid semver. Must be X.Y.Z without a 'v' prefix."
+            exit 1
+          fi
+          # Extract the release tag, strip optional leading "v"
           release_tag="${GITHUB_REF#refs/tags/}"
-          echo "Release tag: $release_tag"
+          release_tag_stripped="${release_tag#v}"
+          echo "Release tag: $release_tag (stripped: $release_tag_stripped)"
           # Check if the versions match
-          if [ "$release_tag" != "$manifest_version" ]; then
+          if [ "$release_tag_stripped" != "$manifest_version" ]; then
             echo "Error: Release tag ($release_tag) does not match manifest.json version ($manifest_version)"
             exit 1
           fi
```

### Test plan

The `release.yml` workflow only triggers on GitHub `release` events, so it cannot be exercised against this PR directly. Logic verified locally with bash 5:

```
$ manifest_version=0.6.12
$ [[ "$manifest_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]] && echo ok
ok
$ manifest_version=v0.6.12
$ [[ "$manifest_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]] || echo rejected
rejected
$ release_tag=v0.6.12; echo "${release_tag#v}"
0.6.12
$ release_tag=0.6.12; echo "${release_tag#v}"   # tolerant of tags without v too
0.6.12
```

### Merge order

This PR should be merged **after** #819 so that the first release built with this updated check already has a semver-compliant `manifest.json`. Either order is safe though — the workflow only runs on release events.
