### PR TITLE
fix(entity): subscribe to device updates in async_added_to_hass

### DIFF
--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -27,7 +27,6 @@ class MideaEntity(Entity):
     def __init__(self, device: MideaDevice, entity_key: str) -> None:
         """Initialize Midea base entity."""
         self._device = device
-        self._device.register_update(self.update_state)
         self._config = cast(
             "dict",
             MIDEA_DEVICES[self._device.device_type]["entities"],
@@ -118,6 +117,21 @@ class MideaEntity(Entity):
     def icon(self) -> str:
         """Return entity icon."""
         return cast("str", self._config.get("icon"))
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to device updates once the entity is added to HA.
+
+        Registering the callback here (rather than in ``__init__``) ensures an
+        entity that is constructed but never added to HA never receives updates,
+        which avoids the recurring "HASS is None" warnings.
+        """
+        await super().async_added_to_hass()
+        self._device.register_update(self.update_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from device updates when the entity is removed from HA."""
+        await super().async_will_remove_from_hass()
+        self._device.unregister_update(self.update_state)
 
     @callback
     def update_state(self, status: Any) -> None:  # noqa: ANN401

--- a/doc/AC.md
+++ b/doc/AC.md
@@ -40,10 +40,11 @@ Default mode: 1
 ```
 
 Known settings:
-| Device | Mode |
-| :------------------------------- | ---: |
-| Midea PortaSplit | 12 |
-| Midea 00000Q1D subtype 524 | 101 |
+
+| Device                     | Mode |
+| :------------------------- | ---: |
+| Midea PortaSplit           |   12 |
+| Midea 00000Q1D subtype 524 |  101 |
 
 ## Entities
 


### PR DESCRIPTION
## Problem

The base entity registers its device-update callback in `__init__`:

```python
self._device.register_update(self.update_state)
```

Since this runs at **construction** (before the entity is added to HA), any entity
that is constructed but never actually added — e.g. one whose `unique_id` collides
and is rejected, or one the user did not select — keeps its callback registered.
Every device refresh then calls `update_state` with `self.hass is None`, spamming
the log indefinitely:

```
WARNING ... MideaEntity update_state for Water Consumption [...]: HASS is None
```

## Fix

Move the subscription to the entity lifecycle hooks, which is the standard HA pattern:

- `register_update` in **`async_added_to_hass`** — the callback only fires while the
  entity is in HA, so a never-added entity never receives updates (no more
  "HASS is None").
- `unregister_update` in **`async_will_remove_from_hass`** — clean teardown on
  reload/reconfigure, so callbacks are not leaked.

`unregister_update` has been in `midealocal` since well before the pinned `6.8.0`.
This is **independent** from the wrong-domain `entity_id` issue (#813, PRs
#817/#844/#855) — it only touches the update-callback lifecycle.

## References

Fixes the recurring **"HASS is None"** warning reported in #611 / #612 (previously
only band-aided by the `hass is None` guard). Related callback-lifecycle issues
(not fully resolved here, as they happen during full HA shutdown): #798, #809.
Prior art: #307 (added the shutdown guard), #217 (earlier `register_update`
cleanup attempt, abandoned).

## Testing

No behavioural change for normally-added entities (HA reads their initial state from
the properties on add). Verified on a live setup (E2 water heater + AC): the
recurring "HASS is None" warnings for a deselected sensor stop after the change,
selected entities keep updating, and reloading the integration no longer leaks
callbacks.
