### PR TITLE
docs: add AGENTS.md as shared AI agent guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# GitHub Copilot Instructions
+
+The full project guidance for AI coding agents lives in [`AGENTS.md`](../AGENTS.md) at the repository root.
+Please read and follow it — it is the single source of truth for architecture, commands, and conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+Shared guidance for all AI coding agents (Claude Code, OpenAI Codex, GitHub Copilot, Cursor, Gemini CLI, etc.) working in this repository. This is the single source of truth; tool-specific files (`CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`) point here.
+
+## What this is
+
+A Home Assistant custom integration (distributed via HACS) that controls Midea M-Smart appliances over the local network. This repo is a **thin Home Assistant glue layer**; all device protocol, discovery, encryption, and cloud-token logic lives in the external **`midea-local`** library (imported as `midealocal`, pinned in `custom_components/midea_ac_lan/manifest.json` → `requirements`). When device behavior or a new attribute is missing, the fix is often in `midea-local`, not here.
+
+Integration code lives entirely in `custom_components/midea_ac_lan/`. Minimum Home Assistant: **2024.4.1**; target Python **3.12+**.
+
+## Architecture
+
+### The device registry (`midea_devices.py`) is the center of everything
+
+`MIDEA_DEVICES: dict[int, ...]` maps a device-type hex code (e.g. `0xAC`, `0xA1`) to `{"name": ..., "entities": {...}}`. Each entry in `entities` maps a **device attribute** (a `DeviceAttributes` enum member imported from `midealocal.devices.<type>`) to a config dict describing which HA platform represents it and its metadata:
+
+```python
+ACAttributes.eco_mode: {
+    "type": Platform.SWITCH,        # which HA platform renders this attribute
+    "translation_key": "eco_mode",  # UI name via translations/<lang>.json
+    "icon": "mdi:leaf",
+    "default": True,                # optional: main entity, created without opt-in
+}
+```
+
+This one table drives every platform. To **add support for a new attribute/entity**, add a row here — you usually do not touch the platform files.
+
+### Platform files follow one identical pattern
+
+`switch.py`, `sensor.py`, `binary_sensor.py`, `select.py`, `number.py`, `lock.py`, `fan.py`, `light.py`, `climate.py`, `water_heater.py`, `humidifier.py` each define `async_setup_entry` that: looks up the device, iterates `MIDEA_DEVICES[device.device_type]["entities"]`, and creates an entity for every row whose `config["type"]` matches that platform.
+
+- **Extra entities** (sensors/switches/etc.): only created if the user opted in — `entity_key in config_entry.options.get(CONF_SENSORS/CONF_SWITCHES, [])`.
+- **Main control entities** (climate, fan, light, water_heater, humidifier): created when `config.get("default")` is true, regardless of opt-in.
+- Platform groupings live in `const.py`: `EXTRA_SENSOR`, `EXTRA_SWITCH`, `EXTRA_CONTROL`, `ALL_PLATFORM`.
+
+`midea_entity.py` — `MideaEntity` base class shared by all platforms. It reads the entity's config dict from `MIDEA_DEVICES`, wires `device.register_update(self.update_state)` for local-push updates, and implements the entity-name/translation precedence (see the long comment block in that file: `translation_key` → explicit `name` → `device_class` → device name).
+
+Note: simple platforms (switch, sensor, …) are generic and data-driven. Complex platforms (`climate.py`, `water_heater.py`, `fan.py`) contain **per-device-type subclasses** (e.g. `MideaACClimate`, `MideaCCClimate`, `MideaC3Climate`) selected by `device.device_type` in their `async_setup_entry`.
+
+### Lifecycle & data flow (`__init__.py`)
+
+`async_setup` registers two services (`set_attribute`, `send_command`; see `services.yaml`). `async_setup_entry` calls `midealocal.devices.device_selector(...)` to build the `MideaDevice`, calls `device.open()` (starts the long-lived TCP connection), and stores it in `hass.data[DOMAIN][DEVICES][device_id]`. Entities read/write via `device.get_attribute()` / `device.set_attribute()`. `update_listener` re-applies options (customize JSON, IP, refresh interval) on config change. `async_migrate_entry` handles config-entry schema migrations (v1→v2 device identifiers).
+
+### Config & options flow (`config_flow.py`)
+
+`MideaLanConfigFlow` handles discovery/manual add and fetching Token+Key from the Midea cloud (`midealocal.cloud`); `MideaLanOptionsFlowHandler` handles per-device options (IP, refresh interval, extra sensor/switch selection, customize). Successfully-added V3 devices are cached to `.storage/midea_ac_lan/<device_id>.json` and reloaded on re-add.
+
+### Home Assistant multi-version compatibility
+
+The integration supports a wide HA version range by branching on `(MAJOR_VERSION, MINOR_VERSION)` (imported from `homeassistant.const`). When using newer HA APIs, guard them this way — grep the codebase for `MAJOR_VERSION` for examples.
+
+## Common commands
+
+Dev environment is a **VS Code Dev Container** (`.devcontainer/`); `scripts/setup.sh` runs on create (installs pre-commit hooks + commit-msg hooks).
+
+```bash
+scripts/run.sh          # run Home Assistant locally with ./config, integration on PYTHONPATH (port 8123)
+scripts/setup.sh        # install pre-commit + commit-msg hooks, create ./config
+```
+
+Linting / checks (all enforced in CI via pre-commit — there is no separate test suite in this repo):
+
+```bash
+pre-commit run --all-files      # run everything: ruff, ruff-format, mypy, pylint, codespell, commitlint, prettier
+ruff check .                    # lint (config: ruff.toml, lint.select = ALL, target py312)
+ruff format .                   # format
+scripts/mypy.sh                 # mypy (config: mypy.ini) — note: NOT `mypy .` directly
+pylint custom_components        # pylint (config: pylintrc)
+```
+
+Install dev deps for a given HA/Python version (each pins a different `homeassistant==`):
+
+```bash
+pip install -r requirements-dev-3.12.txt   # or -3.13 / -3.14
+```
+
+## Conventions
+
+- **Commits must follow Conventional Commits** — enforced by commitlint + commitizen on the `commit-msg` hook. Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`. Releases are automated from these messages (see recent `chore(main): midea_ac_lan release vX.Y.Z` commits).
+- **Do not commit directly to `main`** — blocked by a pre-commit hook; branch and open a PR.
+- **Releasing** bumps `version` in `manifest.json`, which must be valid semver **without a `v` prefix** (HACS 2.0+ rejects `v`-prefixed); enforced by `.github/workflows/release.yml`.
+- **Adding a new device type**: bump the `midea-local` pin in `manifest.json`, add a `0xXX` entry to `MIDEA_DEVICES` in `midea_devices.py`, add a `doc/<TYPE>.md` (+ `_hans` Chinese variant) and a row in `README.md`'s supported-appliances table. Add UI strings to `custom_components/midea_ac_lan/translations/en.json` (and other locales) keyed by `translation_key`.
+- CI validation: `.github/workflows/linter.yml` (pre-commit) and `validate.yml` (HACS + hassfest).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+The full, tool-agnostic project guidance lives in **[AGENTS.md](AGENTS.md)** — the single source of truth shared by all AI coding agents (architecture, commands, conventions). It is imported below.
+
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,5 @@
+# GEMINI.md
+
+Project guidance for the Gemini CLI. The single source of truth for all AI agents is AGENTS.md, imported below.
+
+@./AGENTS.md

--- a/doc/AC.md
+++ b/doc/AC.md
@@ -40,10 +40,11 @@ Default mode: 1
 ```
 
 Known settings:
-| Device | Mode |
-| :------------------------------- | ---: |
-| Midea PortaSplit | 12 |
-| Midea 00000Q1D subtype 524 | 101 |
+
+| Device                     | Mode |
+| :------------------------- | ---: |
+| Midea PortaSplit           |   12 |
+| Midea 00000Q1D subtype 524 |  101 |
 
 ## Entities
 


### PR DESCRIPTION
## Summary

Adds **`AGENTS.md`** as the single, tool-agnostic source of truth for AI coding agents, with thin pointer files so every major agent resolves to the same content without duplication.

`AGENTS.md` is a Linux-Foundation-governed open standard read **natively** by OpenAI Codex, GitHub Copilot Coding Agent, Cursor, Windsurf, Zed, and 25+ tools. Claude Code and Gemini CLI keep their own primary files but reference/import it.

## Files

| File | Role |
|------|------|
| `AGENTS.md` | Full guidance — architecture, commands, conventions (source of truth) |
| `CLAUDE.md` | Thin: `/init` preamble + `@AGENTS.md` import (Claude Code auto-inlines it) |
| `GEMINI.md` | Thin: `@./AGENTS.md` import (Gemini CLI) |
| `.github/copilot-instructions.md` | Thin: text pointer to `../AGENTS.md` (classic in-editor Copilot; no import syntax) |

No file is needed for Codex / Cursor / Windsurf / Zed — they read `AGENTS.md` natively.

## Content

Documentation only — no code changes. `AGENTS.md` captures the non-obvious architecture:

- **`midea_devices.py` registry** as the center — one `MIDEA_DEVICES` table maps device-type hex codes → attributes → HA platforms; adding an entity is usually a one-row change.
- The **shared data-driven `async_setup_entry` pattern** across all platforms, and the extra-entity opt-in vs. `default` main-entity distinction.
- **Thin-glue-over-`midealocal`** framing, so contributors know protocol fixes often belong in the external library.
- Lifecycle/config-flow, HA multi-version `MAJOR_VERSION` guarding, lint commands (pre-commit / ruff / mypy / pylint), and project conventions (Conventional Commits, no direct commits to `main`, semver-without-`v` releases).

## Verification

- Prettier (the CI formatter) passes on all four files.
- `CLAUDE.md` and `GEMINI.md` end with a bare `@`-import line so their CLIs auto-inline `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)