### PR TITLE
refactor(entity): downgrade now-defensive "HASS is None" log to debug

### DIFF
--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -137,7 +137,10 @@ class MideaEntity(Entity):
     def update_state(self, status: Any) -> None:  # noqa: ANN401
         """Update entity state."""
         if not self.hass:
-            _LOGGER.warning(
+            # Defensive guard for the is_stopping access below. Since the update
+            # callback is now registered in async_added_to_hass (#869), hass is
+            # always set on the normal path, so this is debug (like is_stopping).
+            _LOGGER.debug(
                 "MideaEntity update_state for %s [%s] with status %s: HASS is None",
                 self.name,
                 type(self),


### PR DESCRIPTION
## Context

Follow-up to #869, which moved the device-update subscription into
`async_added_to_hass` / `async_will_remove_from_hass`.

## Change

Since the callback is now registered only once the entity is added to HA,
`self.hass` is always set when `update_state` runs on the normal path. The
`if not self.hass:` branch is therefore effectively dead code, and logging it at
`warning` level is misleading.

This downgrades that log to `debug`, matching the adjacent `is_stopping` guard.
The branch itself is **kept** as a defensive guard for the `self.hass.is_stopping`
access on the next line.

As noted by @wuwentao in the #869 review:

> The `"HASS is None"` warning branch in `update_state` is now effectively dead
> code [...] it could be downgraded to `debug` in a future cleanup since it should
> no longer occur in practice.

No functional change — log level only.
