### PR TITLE
fix(i18n): sync all locale translations with en.json base

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     hooks:
       - id: codespell
         args: ["-L hass,lookin,nam,astroid,moteur", "-w"]
-        exclude: "uv\\.lock|custom_components/midea_ac_lan/translations/(de|es|fr|hu).json"
+        exclude: "uv\\.lock|custom_components/midea_ac_lan/translations/(de|es|fr|hu|it).json"
   - repo: local
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     hooks:
       - id: codespell
         args: ["-L hass,lookin,nam,astroid,moteur", "-w"]
-        exclude: "uv\\.lock|custom_components/midea_ac_lan/translations/(de|es|fr).json"
+        exclude: "uv\\.lock|custom_components/midea_ac_lan/translations/(de|es|fr|hu).json"
   - repo: local
     hooks:
       - id: mypy

--- a/custom_components/midea_ac_lan/translations/de.json
+++ b/custom_components/midea_ac_lan/translations/de.json
@@ -144,6 +144,21 @@
       "middle_compartment_preheating": {
         "name": "Middle Compartment Preheating"
       },
+      "top_elec_heat": {
+        "name": "Elektroheizung oben"
+      },
+      "bottom_elec_heat": {
+        "name": "Elektroheizung unten"
+      },
+      "mute_effect": {
+        "name": "Stummschaltung aktiv"
+      },
+      "mute_status": {
+        "name": "Stummschaltungsstatus"
+      },
+      "multi_terminal": {
+        "name": "Multi-Terminal"
+      },
       "oilcup_full": {
         "name": "Oil-cup Full"
       },
@@ -167,6 +182,24 @@
       },
       "seat_status": {
         "name": "Seat Status"
+      },
+      "smart_grid": {
+        "name": "Smart Grid"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "Wartungserinnerung"
+      },
+      "maintain_warn": {
+        "name": "Wartungswarnung"
+      },
+      "order1_effect": {
+        "name": "Zeitplan 1 aktiv"
+      },
+      "order2_effect": {
+        "name": "Zeitplan 2 aktiv"
       },
       "status_dhw": {
         "name": "DHW status"
@@ -215,6 +248,20 @@
       },
       "zone2_water_temp_mode": {
         "name": "Zone2 Water-temperature Mode"
+      },
+      "microcrystal_fresh": {
+        "name": "Mikrokristall-Frische"
+      },
+      "electronic_smell": {
+        "name": "Desodorieren und Sterilisieren"
+      },
+      "water_pump_running": {
+        "name": "Wasserpumpe läuft"
+      }
+    },
+    "button": {
+      "start": {
+        "name": "Start"
       }
     },
     "climate": {
@@ -223,11 +270,24 @@
       },
       "climate_zone2": {
         "name": "Zone2 Thermostat"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "Leise",
+              "full": "Voll"
+            }
+          }
+        }
       }
     },
     "fan": {
       "fresh_air": {
         "name": "Fresh Air"
+      },
+      "fresh_air_exhaust": {
+        "name": "Frischluft-Abluft"
       }
     },
     "lock": {
@@ -248,6 +308,12 @@
       "water_temp_level": {
         "name": "Water Temperature Level"
       },
+      "fan_speed_percent": {
+        "name": "Lüftergeschwindigkeit (Prozent)"
+      },
+      "vacation_days": {
+        "name": "Urlaubstage"
+      },
       "leak_water_protection_value": {
         "name": "Leckschutzwert"
       },
@@ -267,6 +333,25 @@
       },
       "fan_speed": {
         "name": "Fan Speed"
+      },
+      "fresh_air_exhaust_mode": {
+        "name": "Frischluft-Abluftgeschwindigkeit",
+        "state": {
+          "off": "Aus",
+          "silent": "Niedrig",
+          "high": "Hoch",
+          "full": "Voll"
+        }
+      },
+      "fresh_air_mode": {
+        "name": "Frischluftgeschwindigkeit",
+        "state": {
+          "off": "Aus",
+          "low": "Niedrig",
+          "medium": "Mittel",
+          "high": "Hoch",
+          "full": "Voll"
+        }
       },
       "mode": {
         "name": "Mode"
@@ -289,8 +374,33 @@
       "tilting_angle": {
         "name": "Tilting Angle"
       },
+      "wash_mode": {
+        "name": "Waschmodus"
+      },
       "water_level_set": {
         "name": "Water Level Setting"
+      },
+      "wind_lr_angle": {
+        "name": "Luftstrom horizontal",
+        "state": {
+          "off": "Aus",
+          "left": "Links",
+          "left-mid": "Links-Mitte",
+          "middle": "Mitte",
+          "right-mid": "Rechts-Mitte",
+          "right": "Rechts"
+        }
+      },
+      "wind_ud_angle": {
+        "name": "Luftstrom vertikal",
+        "state": {
+          "off": "Aus",
+          "up": "Oben",
+          "up-mid": "Oben-Mitte",
+          "middle": "Mitte",
+          "down-mid": "Unten-Mitte",
+          "down": "Unten"
+        }
       }
     },
     "time": {
@@ -335,8 +445,44 @@
       "dehydration_time": {
         "name": "dehydration time"
       },
+      "dehydration_time_value": {
+        "name": "Schleuderzeitwert"
+      },
+      "temperature": {
+        "name": "Temperatur"
+      },
+      "wash_time_value": {
+        "name": "Waschzeitwert"
+      },
+      "stains": {
+        "name": "Flecken"
+      },
+      "dirty_degree": {
+        "name": "Verschmutzungsgrad"
+      },
       "detergent": {
         "name": "detergent"
+      },
+      "intensity": {
+        "name": "Intensität"
+      },
+      "dryness_level": {
+        "name": "Trocknungsgrad"
+      },
+      "dry_temperature": {
+        "name": "Trocknungstemperatur"
+      },
+      "door_warn": {
+        "name": "Türwarnung"
+      },
+      "ai_switch": {
+        "name": "KI-Schalter"
+      },
+      "material": {
+        "name": "Material"
+      },
+      "water_box": {
+        "name": "Wasserbehälter"
       },
       "energy_consumption": {
         "name": "Energy Consumption"
@@ -357,6 +503,12 @@
       },
       "error_code": {
         "name": "Error Code"
+      },
+      "estimated_energy_consumption": {
+        "name": "Geschätzter Energieverbrauch"
+      },
+      "estimated_water_consumption": {
+        "name": "Geschätzter Wasserverbrauch"
       },
       "fan_level": {
         "name": "Fan level"
@@ -511,9 +663,6 @@
       "target_temperature": {
         "name": "Target Temperature"
       },
-      "temperature": {
-        "name": "Temperatur"
-      },
       "time_remaining": {
         "name": "Time Remaining"
       },
@@ -537,12 +686,6 @@
       },
       "tvoc": {
         "name": "TVOC"
-      },
-      "use_days": {
-        "name": "Nutzungstage"
-      },
-      "velocity": {
-        "name": "Durchflussgeschwindigkeit"
       },
       "wash_level": {
         "name": "rinse count"
@@ -568,8 +711,98 @@
       "water_level": {
         "name": "Water Level"
       },
+      "wind": {
+        "name": "Wind"
+      },
+      "typeinfo": {
+        "name": "Typinformation"
+      },
+      "use_days": {
+        "name": "Nutzungstage"
+      },
+      "elec_heat": {
+        "name": "Elektroheizung"
+      },
+      "water_pump": {
+        "name": "Wasserpumpe"
+      },
+      "four_way": {
+        "name": "Vierwegeventil"
+      },
+      "back_water": {
+        "name": "Rücklaufwasser"
+      },
+      "sterilize": {
+        "name": "Sterilisieren"
+      },
+      "disinfection_temperature": {
+        "name": "Desinfektionstemperatur"
+      },
+      "max_temperature": {
+        "name": "Maximale Zieltemperatur"
+      },
+      "vacation_start_year": {
+        "name": "Urlaubsbeginn Jahr"
+      },
+      "vacation_start_month": {
+        "name": "Urlaubsbeginn Monat"
+      },
+      "vacation_start_day": {
+        "name": "Urlaubsbeginn Tag"
+      },
+      "auto_sterilize_week": {
+        "name": "Auto-Sterilisieren Woche"
+      },
+      "auto_sterilize_hour": {
+        "name": "Auto-Sterilisieren Stunde"
+      },
+      "auto_sterilize_minute": {
+        "name": "Auto-Sterilisieren Minute"
+      },
       "working_time": {
         "name": "Working Time"
+      },
+      "humidity": {
+        "name": "Luftfeuchtigkeit"
+      },
+      "variable_mode": {
+        "name": "Variabler Modus"
+      },
+      "compressor_frequency": {
+        "name": "Kompressorfrequenz"
+      },
+      "target_compressor_frequency": {
+        "name": "Ziel-Kompressorfrequenz"
+      },
+      "compressor_current": {
+        "name": "Kompressorstrom"
+      },
+      "compressor_voltage": {
+        "name": "Kompressorspannung"
+      },
+      "compressor_power": {
+        "name": "Kompressorleistung"
+      },
+      "indoor_coil_temperature": {
+        "name": "Innenraum-Wärmetauschertemperatur (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "Verdampfertemperatur (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "Außenumgebungstemperatur (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Druckleitungstemperatur (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "Innenlüftergeschwindigkeit"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Ziel-Innenlüftergeschwindigkeit"
+      },
+      "velocity": {
+        "name": "Durchflussgeschwindigkeit"
       }
     },
     "switch": {
@@ -600,11 +833,23 @@
       "disinfect": {
         "name": "Disinfect"
       },
+      "vacation_mode": {
+        "name": "Urlaubsmodus"
+      },
       "dry": {
         "name": "Dry"
       },
+      "cold_water_single": {
+        "name": "Kaltwasser einzeln"
+      },
+      "cold_water_dot": {
+        "name": "Kaltwasser Punkt"
+      },
       "eco_mode": {
         "name": "ECO Mode"
+      },
+      "memory": {
+        "name": "Memo U"
       },
       "fast_dhw": {
         "name": "Fast DHW"
@@ -678,6 +923,9 @@
       "sleep_mode": {
         "name": "Sleep Mode"
       },
+      "out_silent": {
+        "name": "Außengerät Leisemodus"
+      },
       "smart_eye": {
         "name": "Smart Eye"
       },
@@ -695,6 +943,9 @@
       },
       "start": {
         "name": "Start"
+      },
+      "sterilization": {
+        "name": "Sterilisation"
       },
       "storage": {
         "name": "Storage"

--- a/custom_components/midea_ac_lan/translations/en.json
+++ b/custom_components/midea_ac_lan/translations/en.json
@@ -246,6 +246,9 @@
       "zone2_room_temp_mode": {
         "name": "Zone2 Room-temperature Mode"
       },
+      "zone2_water_temp_mode": {
+        "name": "Zone2 Water-temperature Mode"
+      },
       "microcrystal_fresh": {
         "name": "Microcrystal Fresh"
       },
@@ -683,6 +686,9 @@
       },
       "tvoc": {
         "name": "TVOC"
+      },
+      "wash_level": {
+        "name": "Rinse count"
       },
       "wash_strength": {
         "name": "Wash strength"

--- a/custom_components/midea_ac_lan/translations/es.json
+++ b/custom_components/midea_ac_lan/translations/es.json
@@ -144,6 +144,21 @@
       "middle_compartment_preheating": {
         "name": "Precalentamiento del compartimento medio"
       },
+      "top_elec_heat": {
+        "name": "Calefacción eléctrica superior"
+      },
+      "bottom_elec_heat": {
+        "name": "Calefacción eléctrica inferior"
+      },
+      "mute_effect": {
+        "name": "Efecto de silencio"
+      },
+      "mute_status": {
+        "name": "Estado de silencio"
+      },
+      "multi_terminal": {
+        "name": "Terminal múltiple"
+      },
       "oilcup_full": {
         "name": "Depósito de aceite lleno"
       },
@@ -167,6 +182,24 @@
       },
       "seat_status": {
         "name": "Estado del asiento"
+      },
+      "smart_grid": {
+        "name": "Red inteligente"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "Recordatorio de mantenimiento"
+      },
+      "maintain_warn": {
+        "name": "Advertencia de mantenimiento"
+      },
+      "order1_effect": {
+        "name": "Programación 1 activa"
+      },
+      "order2_effect": {
+        "name": "Programación 2 activa"
       },
       "status_dhw": {
         "name": "Estado ACS"
@@ -213,11 +246,22 @@
       "zone2_room_temp_mode": {
         "name": "Zona 2 Modo temperatura ambiente"
       },
+      "zone2_water_temp_mode": {
+        "name": "Zona 2 Modo temperatura del agua"
+      },
       "microcrystal_fresh": {
         "name": "Frescura microcristalina"
       },
       "electronic_smell": {
         "name": "Esterilización desodorizante"
+      },
+      "water_pump_running": {
+        "name": "Bomba de agua en funcionamiento"
+      }
+    },
+    "button": {
+      "start": {
+        "name": "Iniciar"
       }
     },
     "climate": {
@@ -241,6 +285,9 @@
     "fan": {
       "fresh_air": {
         "name": "Aire fresco"
+      },
+      "fresh_air_exhaust": {
+        "name": "Extracción de aire fresco"
       }
     },
     "lock": {
@@ -264,6 +311,9 @@
       "fan_speed_percent": {
         "name": "Porcentaje de velocidad del ventilador"
       },
+      "vacation_days": {
+        "name": "Días de vacaciones"
+      },
       "leak_water_protection_value": {
         "name": "Valor de protección contra fugas"
       },
@@ -283,6 +333,25 @@
       },
       "fan_speed": {
         "name": "Velocidad del ventilador"
+      },
+      "fresh_air_exhaust_mode": {
+        "name": "Velocidad de extracción de aire fresco",
+        "state": {
+          "off": "Apagado",
+          "silent": "Baja",
+          "high": "Alta",
+          "full": "Máximo"
+        }
+      },
+      "fresh_air_mode": {
+        "name": "Velocidad de aire fresco",
+        "state": {
+          "off": "Apagado",
+          "low": "Baja",
+          "medium": "Media",
+          "high": "Alta",
+          "full": "Máximo"
+        }
       },
       "mode": {
         "name": "Modo"
@@ -304,6 +373,9 @@
       },
       "tilting_angle": {
         "name": "Ángulo de inclinación"
+      },
+      "wash_mode": {
+        "name": "Modo de lavado"
       },
       "water_level_set": {
         "name": "Ajuste de nivel de agua"
@@ -431,6 +503,12 @@
       },
       "error_code": {
         "name": "Código de error"
+      },
+      "estimated_energy_consumption": {
+        "name": "Consumo estimado de energía"
+      },
+      "estimated_water_consumption": {
+        "name": "Consumo estimado de agua"
       },
       "fan_level": {
         "name": "Nivel del ventilador"
@@ -609,8 +687,8 @@
       "tvoc": {
         "name": "COVT"
       },
-      "use_days": {
-        "name": "Días de uso"
+      "wash_level": {
+        "name": "Recuento de aclarados"
       },
       "wash_strength": {
         "name": "Potencia de lavado"
@@ -633,6 +711,54 @@
       "water_level": {
         "name": "Nivel de agua"
       },
+      "wind": {
+        "name": "Viento"
+      },
+      "typeinfo": {
+        "name": "Información de tipo"
+      },
+      "use_days": {
+        "name": "Días de uso"
+      },
+      "elec_heat": {
+        "name": "Calefacción eléctrica"
+      },
+      "water_pump": {
+        "name": "Bomba de agua"
+      },
+      "four_way": {
+        "name": "Válvula de cuatro vías"
+      },
+      "back_water": {
+        "name": "Retorno de agua"
+      },
+      "sterilize": {
+        "name": "Esterilizar"
+      },
+      "disinfection_temperature": {
+        "name": "Temperatura de desinfección"
+      },
+      "max_temperature": {
+        "name": "Temperatura objetivo máxima"
+      },
+      "vacation_start_year": {
+        "name": "Año de inicio de vacaciones"
+      },
+      "vacation_start_month": {
+        "name": "Mes de inicio de vacaciones"
+      },
+      "vacation_start_day": {
+        "name": "Día de inicio de vacaciones"
+      },
+      "auto_sterilize_week": {
+        "name": "Semana de esterilización automática"
+      },
+      "auto_sterilize_hour": {
+        "name": "Hora de esterilización automática"
+      },
+      "auto_sterilize_minute": {
+        "name": "Minuto de esterilización automática"
+      },
       "working_time": {
         "name": "Tiempo de funcionamiento"
       },
@@ -641,6 +767,39 @@
       },
       "variable_mode": {
         "name": "Modo variable"
+      },
+      "compressor_frequency": {
+        "name": "Frecuencia del compresor"
+      },
+      "target_compressor_frequency": {
+        "name": "Frecuencia objetivo del compresor"
+      },
+      "compressor_current": {
+        "name": "Corriente del compresor"
+      },
+      "compressor_voltage": {
+        "name": "Voltaje del compresor"
+      },
+      "compressor_power": {
+        "name": "Potencia del compresor"
+      },
+      "indoor_coil_temperature": {
+        "name": "Temperatura del serpentín interior (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "Temperatura del evaporador (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "Temperatura ambiente exterior (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Temperatura del tubo de descarga (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "Velocidad del ventilador interior"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Velocidad objetivo del ventilador interior"
       },
       "velocity": {
         "name": "Velocidad"
@@ -674,6 +833,9 @@
       "disinfect": {
         "name": "Desinfectar"
       },
+      "vacation_mode": {
+        "name": "Modo vacaciones"
+      },
       "dry": {
         "name": "Secado"
       },
@@ -685,6 +847,9 @@
       },
       "eco_mode": {
         "name": "Modo ECO"
+      },
+      "memory": {
+        "name": "Memo U"
       },
       "fast_dhw": {
         "name": "ACS Rápido"
@@ -758,6 +923,9 @@
       "sleep_mode": {
         "name": "Modo sueño"
       },
+      "out_silent": {
+        "name": "Modo silencioso exterior"
+      },
       "smart_eye": {
         "name": "Ojo inteligente"
       },
@@ -775,6 +943,9 @@
       },
       "start": {
         "name": "Iniciar"
+      },
+      "sterilization": {
+        "name": "Esterilización"
       },
       "storage": {
         "name": "Almacenamiento"

--- a/custom_components/midea_ac_lan/translations/fr.json
+++ b/custom_components/midea_ac_lan/translations/fr.json
@@ -144,6 +144,21 @@
       "middle_compartment_preheating": {
         "name": "Middle Compartment Preheating"
       },
+      "top_elec_heat": {
+        "name": "Chauffage électrique supérieur"
+      },
+      "bottom_elec_heat": {
+        "name": "Chauffage électrique inférieur"
+      },
+      "mute_effect": {
+        "name": "Effet silencieux"
+      },
+      "mute_status": {
+        "name": "État silencieux"
+      },
+      "multi_terminal": {
+        "name": "Multi-terminal"
+      },
       "oilcup_full": {
         "name": "Oil-cup Full"
       },
@@ -167,6 +182,24 @@
       },
       "seat_status": {
         "name": "Seat Status"
+      },
+      "smart_grid": {
+        "name": "Réseau intelligent"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "Rappel d'entretien"
+      },
+      "maintain_warn": {
+        "name": "Avertissement d'entretien"
+      },
+      "order1_effect": {
+        "name": "Programmation 1 active"
+      },
+      "order2_effect": {
+        "name": "Programmation 2 active"
       },
       "status_dhw": {
         "name": "DHW status"
@@ -215,6 +248,20 @@
       },
       "zone2_water_temp_mode": {
         "name": "Zone2 Water-temperature Mode"
+      },
+      "microcrystal_fresh": {
+        "name": "Fraîcheur microcristal"
+      },
+      "electronic_smell": {
+        "name": "Désodorisation stérilisation"
+      },
+      "water_pump_running": {
+        "name": "Pompe à eau en marche"
+      }
+    },
+    "button": {
+      "start": {
+        "name": "Démarrer"
       }
     },
     "climate": {
@@ -223,11 +270,24 @@
       },
       "climate_zone2": {
         "name": "Zone2 Thermostat"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "Silencieux",
+              "full": "Maximum"
+            }
+          }
+        }
       }
     },
     "fan": {
       "fresh_air": {
         "name": "Fresh Air"
+      },
+      "fresh_air_exhaust": {
+        "name": "Extraction d'air frais"
       }
     },
     "lock": {
@@ -248,6 +308,12 @@
       "water_temp_level": {
         "name": "Water Temperature Level"
       },
+      "fan_speed_percent": {
+        "name": "Pourcentage de vitesse du ventilateur"
+      },
+      "vacation_days": {
+        "name": "Jours de vacances"
+      },
       "leak_water_protection_value": {
         "name": "Valeur de protection contre les fuites"
       },
@@ -267,6 +333,25 @@
       },
       "fan_speed": {
         "name": "Fan Speed"
+      },
+      "fresh_air_exhaust_mode": {
+        "name": "Vitesse d'extraction d'air frais",
+        "state": {
+          "off": "Arrêt",
+          "silent": "Faible",
+          "high": "Élevée",
+          "full": "Maximum"
+        }
+      },
+      "fresh_air_mode": {
+        "name": "Vitesse d'air frais",
+        "state": {
+          "off": "Arrêt",
+          "low": "Faible",
+          "medium": "Moyenne",
+          "high": "Élevée",
+          "full": "Maximum"
+        }
       },
       "mode": {
         "name": "Mode"
@@ -289,8 +374,33 @@
       "tilting_angle": {
         "name": "Tilting Angle"
       },
+      "wash_mode": {
+        "name": "Mode de lavage"
+      },
       "water_level_set": {
         "name": "Water Level Setting"
+      },
+      "wind_lr_angle": {
+        "name": "Flux d'air horizontal",
+        "state": {
+          "off": "Arrêt",
+          "left": "Gauche",
+          "left-mid": "Centre-gauche",
+          "middle": "Centre",
+          "right-mid": "Centre-droite",
+          "right": "Droite"
+        }
+      },
+      "wind_ud_angle": {
+        "name": "Flux d'air vertical",
+        "state": {
+          "off": "Arrêt",
+          "up": "Haut",
+          "up-mid": "Centre-haut",
+          "middle": "Centre",
+          "down-mid": "Centre-bas",
+          "down": "Bas"
+        }
       }
     },
     "time": {
@@ -335,8 +445,44 @@
       "dehydration_time": {
         "name": "dehydration time"
       },
+      "dehydration_time_value": {
+        "name": "Valeur du temps d'essorage"
+      },
+      "temperature": {
+        "name": "Température"
+      },
+      "wash_time_value": {
+        "name": "Valeur du temps de lavage"
+      },
+      "stains": {
+        "name": "Taches"
+      },
+      "dirty_degree": {
+        "name": "Degré de saleté"
+      },
       "detergent": {
         "name": "detergent"
+      },
+      "intensity": {
+        "name": "Intensité"
+      },
+      "dryness_level": {
+        "name": "Niveau de séchage"
+      },
+      "dry_temperature": {
+        "name": "Température de séchage"
+      },
+      "door_warn": {
+        "name": "Alerte de porte"
+      },
+      "ai_switch": {
+        "name": "Interrupteur IA"
+      },
+      "material": {
+        "name": "Matériau"
+      },
+      "water_box": {
+        "name": "Réservoir d'eau"
       },
       "energy_consumption": {
         "name": "Energy Consumption"
@@ -357,6 +503,12 @@
       },
       "error_code": {
         "name": "Error Code"
+      },
+      "estimated_energy_consumption": {
+        "name": "Consommation d'énergie estimée"
+      },
+      "estimated_water_consumption": {
+        "name": "Consommation d'eau estimée"
       },
       "fan_level": {
         "name": "Fan level"
@@ -511,9 +663,6 @@
       "target_temperature": {
         "name": "Target Temperature"
       },
-      "temperature": {
-        "name": "Température"
-      },
       "time_remaining": {
         "name": "Time Remaining"
       },
@@ -537,12 +686,6 @@
       },
       "tvoc": {
         "name": "TVOC"
-      },
-      "use_days": {
-        "name": "Jours d'utilisation"
-      },
-      "velocity": {
-        "name": "Vitesse"
       },
       "wash_level": {
         "name": "rinse count"
@@ -568,8 +711,98 @@
       "water_level": {
         "name": "Water Level"
       },
+      "wind": {
+        "name": "Vent"
+      },
+      "typeinfo": {
+        "name": "Informations de type"
+      },
+      "use_days": {
+        "name": "Jours d'utilisation"
+      },
+      "elec_heat": {
+        "name": "Chauffage électrique"
+      },
+      "water_pump": {
+        "name": "Pompe à eau"
+      },
+      "four_way": {
+        "name": "Vanne quatre voies"
+      },
+      "back_water": {
+        "name": "Retour d'eau"
+      },
+      "sterilize": {
+        "name": "Stériliser"
+      },
+      "disinfection_temperature": {
+        "name": "Température de désinfection"
+      },
+      "max_temperature": {
+        "name": "Température cible maximale"
+      },
+      "vacation_start_year": {
+        "name": "Année de début des vacances"
+      },
+      "vacation_start_month": {
+        "name": "Mois de début des vacances"
+      },
+      "vacation_start_day": {
+        "name": "Jour de début des vacances"
+      },
+      "auto_sterilize_week": {
+        "name": "Semaine de stérilisation automatique"
+      },
+      "auto_sterilize_hour": {
+        "name": "Heure de stérilisation automatique"
+      },
+      "auto_sterilize_minute": {
+        "name": "Minute de stérilisation automatique"
+      },
       "working_time": {
         "name": "Working Time"
+      },
+      "humidity": {
+        "name": "Humidité"
+      },
+      "variable_mode": {
+        "name": "Mode variable"
+      },
+      "compressor_frequency": {
+        "name": "Fréquence du compresseur"
+      },
+      "target_compressor_frequency": {
+        "name": "Fréquence cible du compresseur"
+      },
+      "compressor_current": {
+        "name": "Courant du compresseur"
+      },
+      "compressor_voltage": {
+        "name": "Tension du compresseur"
+      },
+      "compressor_power": {
+        "name": "Puissance du compresseur"
+      },
+      "indoor_coil_temperature": {
+        "name": "Température de la batterie intérieure (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "Température de l'évaporateur (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "Température ambiante extérieure (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Température du tuyau de refoulement (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "Vitesse du ventilateur intérieur"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Vitesse cible du ventilateur intérieur"
+      },
+      "velocity": {
+        "name": "Vitesse"
       }
     },
     "switch": {
@@ -600,8 +833,17 @@
       "disinfect": {
         "name": "Disinfect"
       },
+      "vacation_mode": {
+        "name": "Mode vacances"
+      },
       "dry": {
         "name": "Dry"
+      },
+      "cold_water_single": {
+        "name": "Eau froide simple"
+      },
+      "cold_water_dot": {
+        "name": "Point d'eau froide"
       },
       "eco_mode": {
         "name": "ECO Mode"
@@ -680,6 +922,9 @@
       },
       "sleep_mode": {
         "name": "Sleep Mode"
+      },
+      "out_silent": {
+        "name": "Mode silencieux extérieur"
       },
       "smart_eye": {
         "name": "Smart Eye"

--- a/custom_components/midea_ac_lan/translations/hu.json
+++ b/custom_components/midea_ac_lan/translations/hu.json
@@ -144,6 +144,21 @@
       "middle_compartment_preheating": {
         "name": "Middle Compartment Preheating"
       },
+      "top_elec_heat": {
+        "name": "Felső elektromos fűtés"
+      },
+      "bottom_elec_heat": {
+        "name": "Alsó elektromos fűtés"
+      },
+      "mute_effect": {
+        "name": "Némítás hatása"
+      },
+      "mute_status": {
+        "name": "Némítás állapota"
+      },
+      "multi_terminal": {
+        "name": "Több terminál"
+      },
       "oilcup_full": {
         "name": "Oil-cup Full"
       },
@@ -167,6 +182,24 @@
       },
       "seat_status": {
         "name": "Seat Status"
+      },
+      "smart_grid": {
+        "name": "Okos hálózat"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "Karbantartási emlékeztető"
+      },
+      "maintain_warn": {
+        "name": "Karbantartási figyelmeztetés"
+      },
+      "order1_effect": {
+        "name": "1. ütemezés aktív"
+      },
+      "order2_effect": {
+        "name": "2. ütemezés aktív"
       },
       "status_dhw": {
         "name": "DHW status"
@@ -215,6 +248,20 @@
       },
       "zone2_water_temp_mode": {
         "name": "Zone2 Water-temperature Mode"
+      },
+      "microcrystal_fresh": {
+        "name": "Mikrokristályos frissítés"
+      },
+      "electronic_smell": {
+        "name": "Szagtalanító sterilizálás"
+      },
+      "water_pump_running": {
+        "name": "Vízszivattyú működik"
+      }
+    },
+    "button": {
+      "start": {
+        "name": "Indítás"
       }
     },
     "climate": {
@@ -223,11 +270,24 @@
       },
       "climate_zone2": {
         "name": "Zone2 Thermostat"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "Csendes",
+              "full": "Teljes"
+            }
+          }
+        }
       }
     },
     "fan": {
       "fresh_air": {
         "name": "Fresh Air"
+      },
+      "fresh_air_exhaust": {
+        "name": "Frisslevegő elszívás"
       }
     },
     "lock": {
@@ -248,6 +308,12 @@
       "water_temp_level": {
         "name": "Water Temperature Level"
       },
+      "fan_speed_percent": {
+        "name": "Ventilátor sebesség százalék"
+      },
+      "vacation_days": {
+        "name": "Vakáció napok"
+      },
       "leak_water_protection_value": {
         "name": "Vízszivárgás védelem értéke"
       },
@@ -267,6 +333,25 @@
       },
       "fan_speed": {
         "name": "Fan Speed"
+      },
+      "fresh_air_exhaust_mode": {
+        "name": "Frisslevegő elszívás sebessége",
+        "state": {
+          "off": "Ki",
+          "silent": "Alacsony",
+          "high": "Magas",
+          "full": "Teljes"
+        }
+      },
+      "fresh_air_mode": {
+        "name": "Frisslevegő sebessége",
+        "state": {
+          "off": "Ki",
+          "low": "Alacsony",
+          "medium": "Közepes",
+          "high": "Magas",
+          "full": "Teljes"
+        }
       },
       "mode": {
         "name": "Mode"
@@ -289,8 +374,33 @@
       "tilting_angle": {
         "name": "Tilting Angle"
       },
+      "wash_mode": {
+        "name": "Mosási mód"
+      },
       "water_level_set": {
         "name": "Water Level Setting"
+      },
+      "wind_lr_angle": {
+        "name": "Légáramlás vízszintes",
+        "state": {
+          "off": "Ki",
+          "left": "Bal",
+          "left-mid": "Bal-közép",
+          "middle": "Közép",
+          "right-mid": "Jobb-közép",
+          "right": "Jobb"
+        }
+      },
+      "wind_ud_angle": {
+        "name": "Légáramlás függőleges",
+        "state": {
+          "off": "Ki",
+          "up": "Fel",
+          "up-mid": "Fel-közép",
+          "middle": "Közép",
+          "down-mid": "Le-közép",
+          "down": "Le"
+        }
       }
     },
     "time": {
@@ -335,8 +445,44 @@
       "dehydration_time": {
         "name": "dehydration time"
       },
+      "dehydration_time_value": {
+        "name": "Víztelenítési idő értéke"
+      },
+      "temperature": {
+        "name": "Hőmérséklet"
+      },
+      "wash_time_value": {
+        "name": "Mosási idő értéke"
+      },
+      "stains": {
+        "name": "Foltok"
+      },
+      "dirty_degree": {
+        "name": "Szennyezettség mértéke"
+      },
       "detergent": {
         "name": "detergent"
+      },
+      "intensity": {
+        "name": "Intenzitás"
+      },
+      "dryness_level": {
+        "name": "Szárazsági szint"
+      },
+      "dry_temperature": {
+        "name": "Szárítási hőmérséklet"
+      },
+      "door_warn": {
+        "name": "Ajtó figyelmeztetés"
+      },
+      "ai_switch": {
+        "name": "AI kapcsoló"
+      },
+      "material": {
+        "name": "Anyag"
+      },
+      "water_box": {
+        "name": "Víztartály"
       },
       "energy_consumption": {
         "name": "Energy Consumption"
@@ -357,6 +503,12 @@
       },
       "error_code": {
         "name": "Error Code"
+      },
+      "estimated_energy_consumption": {
+        "name": "Becsült energiafogyasztás"
+      },
+      "estimated_water_consumption": {
+        "name": "Becsült vízfogyasztás"
       },
       "fan_level": {
         "name": "Fan level"
@@ -511,9 +663,6 @@
       "target_temperature": {
         "name": "Target Temperature"
       },
-      "temperature": {
-        "name": "Hőmérséklet"
-      },
       "time_remaining": {
         "name": "Time Remaining"
       },
@@ -537,12 +686,6 @@
       },
       "tvoc": {
         "name": "TVOC"
-      },
-      "use_days": {
-        "name": "Használati napok"
-      },
-      "velocity": {
-        "name": "Sebesség"
       },
       "wash_level": {
         "name": "rinse count"
@@ -568,8 +711,98 @@
       "water_level": {
         "name": "Water Level"
       },
+      "wind": {
+        "name": "Szél"
+      },
+      "typeinfo": {
+        "name": "Típusinformáció"
+      },
+      "use_days": {
+        "name": "Használati napok"
+      },
+      "elec_heat": {
+        "name": "Elektromos fűtés"
+      },
+      "water_pump": {
+        "name": "Vízszivattyú"
+      },
+      "four_way": {
+        "name": "Négyjáratú szelep"
+      },
+      "back_water": {
+        "name": "Visszatérő víz"
+      },
+      "sterilize": {
+        "name": "Sterilizálás"
+      },
+      "disinfection_temperature": {
+        "name": "Fertőtlenítési hőmérséklet"
+      },
+      "max_temperature": {
+        "name": "Maximális cél hőmérséklet"
+      },
+      "vacation_start_year": {
+        "name": "Vakáció kezdő év"
+      },
+      "vacation_start_month": {
+        "name": "Vakáció kezdő hónap"
+      },
+      "vacation_start_day": {
+        "name": "Vakáció kezdő nap"
+      },
+      "auto_sterilize_week": {
+        "name": "Automatikus sterilizálás hét"
+      },
+      "auto_sterilize_hour": {
+        "name": "Automatikus sterilizálás óra"
+      },
+      "auto_sterilize_minute": {
+        "name": "Automatikus sterilizálás perc"
+      },
       "working_time": {
         "name": "Working Time"
+      },
+      "humidity": {
+        "name": "Páratartalom"
+      },
+      "variable_mode": {
+        "name": "Változó mód"
+      },
+      "compressor_frequency": {
+        "name": "Kompresszor frekvencia"
+      },
+      "target_compressor_frequency": {
+        "name": "Cél kompresszor frekvencia"
+      },
+      "compressor_current": {
+        "name": "Kompresszor áramerősség"
+      },
+      "compressor_voltage": {
+        "name": "Kompresszor feszültség"
+      },
+      "compressor_power": {
+        "name": "Kompresszor teljesítmény"
+      },
+      "indoor_coil_temperature": {
+        "name": "Beltéri hőcserélő hőmérséklet (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "Párologtató hőmérséklet (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "Kültéri környezeti hőmérséklet (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Nyomócső hőmérséklet (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "Beltéri ventilátor sebesség"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Cél beltéri ventilátor sebesség"
+      },
+      "velocity": {
+        "name": "Sebesség"
       }
     },
     "switch": {
@@ -600,11 +833,23 @@
       "disinfect": {
         "name": "Disinfect"
       },
+      "vacation_mode": {
+        "name": "Vakáció mód"
+      },
       "dry": {
         "name": "Dry"
       },
+      "cold_water_single": {
+        "name": "Hideg víz egyszeri"
+      },
+      "cold_water_dot": {
+        "name": "Hideg víz pont"
+      },
       "eco_mode": {
         "name": "ECO Mode"
+      },
+      "memory": {
+        "name": "Memo U"
       },
       "fast_dhw": {
         "name": "Fast DHW"
@@ -678,6 +923,9 @@
       "sleep_mode": {
         "name": "Sleep Mode"
       },
+      "out_silent": {
+        "name": "Kültéri csendes mód"
+      },
       "smart_eye": {
         "name": "Smart Eye"
       },
@@ -695,6 +943,9 @@
       },
       "start": {
         "name": "Start"
+      },
+      "sterilization": {
+        "name": "Sterilizálás"
       },
       "storage": {
         "name": "Storage"

--- a/custom_components/midea_ac_lan/translations/it.json
+++ b/custom_components/midea_ac_lan/translations/it.json
@@ -1,0 +1,1066 @@
+{
+  "config": {
+    "error": {
+      "preset_account": "Accesso con account predefinito non riuscito, per favore segnala questo problema",
+      "login_failed": "Accesso non riuscito, account o password errati",
+      "no_devices": "Nessun nuovo elettrodomestico disponibile trovato nella rete",
+      "device_exist": "L’elettrodomestico è già configurato",
+      "config_incorrect": "La configurazione non è corretta",
+      "connect_error": "Impossibile connettersi all’elettrodomestico",
+      "invalid_token": "Token o Chiave in un formato non corretto"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "way": "Aggiunta elettrodomestici"
+        },
+        "description": "Scegli il metodo per aggiungere un elettrodomestico",
+        "title": "Aggiungi nuovo elettrodomestico"
+      },
+      "login": {
+        "data": {
+          "account": "Account",
+          "password": "Password"
+        },
+        "description": "Accedi e salva il tuo account Midea solo per ottenere le informazioni sugli elettrodomestici.\nPuoi rimuovere questa configurazione dopo aver completato la configurazione di tutti gli elettrodomestici.",
+        "title": "Accesso"
+      },
+      "discovery": {
+        "description": "Indirizzo IP del dispositivo, inserisci \"auto\" per rilevarlo automaticamente\nPuoi anche usare un indirizzo IP per cercare in una rete specifica, come \"192.168.1.255\"",
+        "title": "Ricerca",
+        "data": {
+          "ip_address": "Indirizzo IP"
+        }
+      },
+      "list": {
+        "description": "{table}",
+        "title": "Elettrodomestici"
+      },
+      "auto": {
+        "data": {
+          "device": "Elettrodomestici"
+        },
+        "description": "Scegli un elettrodomestico da aggiungere",
+        "title": "Nuovo elettrodomestico trovato"
+      },
+      "manually": {
+        "data": {
+          "name": "Nome (es. Climatizzatore Soggiorno)",
+          "device_id": "Codice elettrodomestico",
+          "type": "Tipo",
+          "ip_address": "Indirizzo IP",
+          "port": "Porta",
+          "model": "Modello",
+          "subtype": "Sottotipo",
+          "protocol": "Protocollo",
+          "token": "Token",
+          "key": "Chiave"
+        },
+        "description": "Configurazione dell’elettrodomestico",
+        "title": "Nuovo elettrodomestico"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "bar_door": {
+        "name": "Porta Bar"
+      },
+      "bar_door_overtime": {
+        "name": "Porta Bar Aperta Troppo a Lungo"
+      },
+      "bathing_working": {
+        "name": "Stato Funzionamento Bagno"
+      },
+      "bottom_compartment_cooling": {
+        "name": "Raffreddamento Scomparto Inferiore"
+      },
+      "bottom_compartment_door": {
+        "name": "Porta Scomparto Inferiore"
+      },
+      "bottom_compartment_preheating": {
+        "name": "Preriscaldamento Scomparto Inferiore"
+      },
+      "burning_state": {
+        "name": "Stato di Combustione"
+      },
+      "cleaning_reminder": {
+        "name": "Promemoria Pulizia"
+      },
+      "compressor_status": {
+        "name": "Stato Compressore"
+      },
+      "cooking": {
+        "name": "Cottura"
+      },
+      "error_code": {
+        "name": "Codice Errore"
+      },
+      "filter_change_reminder": {
+        "name": "Promemoria Cambio Filtro"
+      },
+      "filter_cleaning_reminder": {
+        "name": "Promemoria Pulizia Filtro"
+      },
+      "finished": {
+        "name": "Terminato"
+      },
+      "flex_zone_door": {
+        "name": "Porta Flex"
+      },
+      "flex_zone_door_overtime": {
+        "name": "Porta Zona Flex Aperta Troppo a Lungo"
+      },
+      "freezer_door": {
+        "name": "Porta Freezer"
+      },
+      "freezer_door_overtime": {
+        "name": "Porta Freezer Aperta Troppo a Lungo"
+      },
+      "full_dust": {
+        "name": "Pieno di Polvere"
+      },
+      "heating": {
+        "name": "Riscaldamento"
+      },
+      "heating_working": {
+        "name": "Stato Funzionamento Riscaldamento"
+      },
+      "keep_warm": {
+        "name": "Mantenimento Caldo"
+      },
+      "leak_water": {
+        "name": "Perdita Acqua"
+      },
+      "lid_status": {
+        "name": "Stato Coperchio"
+      },
+      "middle_compartment_cooling": {
+        "name": "Raffreddamento Scomparto Centrale"
+      },
+      "middle_compartment_door": {
+        "name": "Porta Scomparto Centrale"
+      },
+      "middle_compartment_preheating": {
+        "name": "Preriscaldamento Scomparto Centrale"
+      },
+      "top_elec_heat": {
+        "name": "Riscaldamento Elettrico Superiore"
+      },
+      "bottom_elec_heat": {
+        "name": "Riscaldamento Elettrico Inferiore"
+      },
+      "mute_effect": {
+        "name": "Effetto Silenzioso"
+      },
+      "mute_status": {
+        "name": "Stato Silenzioso"
+      },
+      "multi_terminal": {
+        "name": "Multi Terminale"
+      },
+      "oilcup_full": {
+        "name": "Vaschetta Olio Piena"
+      },
+      "protection": {
+        "name": "Protezione"
+      },
+      "refrigerator_door": {
+        "name": "Porta Frigorifero"
+      },
+      "refrigerator_door_overtime": {
+        "name": "Porta Frigorifero Aperta Troppo a Lungo"
+      },
+      "rinse_aid": {
+        "name": "Mancanza Brillantante"
+      },
+      "rsj_stand_by": {
+        "name": "In Attesa"
+      },
+      "salt": {
+        "name": "Mancanza Sale"
+      },
+      "seat_status": {
+        "name": "Stato Sedile"
+      },
+      "smart_grid": {
+        "name": "Smart Grid"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "Promemoria Manutenzione"
+      },
+      "maintain_warn": {
+        "name": "Avviso Manutenzione"
+      },
+      "order1_effect": {
+        "name": "Programma 1 Attivo"
+      },
+      "order2_effect": {
+        "name": "Programma 2 Attivo"
+      },
+      "status_dhw": {
+        "name": "Stato ACS"
+      },
+      "status_heating": {
+        "name": "Stato Riscaldamento"
+      },
+      "status_ibh": {
+        "name": "Stato IBH"
+      },
+      "status_tbh": {
+        "name": "Stato TBH"
+      },
+      "tank_ejected": {
+        "name": "Serbatoio Espulso"
+      },
+      "tank_full": {
+        "name": "Stato Serbatoio"
+      },
+      "top_compartment_cooling": {
+        "name": "Raffreddamento Scomparto Superiore"
+      },
+      "top_compartment_door": {
+        "name": "Porta Scomparto Superiore"
+      },
+      "top_compartment_preheating": {
+        "name": "Preriscaldamento Scomparto Superiore"
+      },
+      "water_change_reminder": {
+        "name": "Promemoria Cambio Acqua"
+      },
+      "water_shortage": {
+        "name": "Mancanza Acqua"
+      },
+      "with_pressure": {
+        "name": "Con Pressione"
+      },
+      "zone1_room_temp_mode": {
+        "name": "Zona1 Modalità Temperatura Ambiente"
+      },
+      "zone1_water_temp_mode": {
+        "name": "Zona1 Modalità Temperatura Acqua"
+      },
+      "zone2_room_temp_mode": {
+        "name": "Zona2 Modalità Temperatura Ambiente"
+      },
+      "zone2_water_temp_mode": {
+        "name": "Zona2 Modalità Temperatura Acqua"
+      },
+      "microcrystal_fresh": {
+        "name": "Freschezza Microcristalli"
+      },
+      "electronic_smell": {
+        "name": "Deodorizzazione e Sterilizzazione"
+      },
+      "water_pump_running": {
+        "name": "Pompa Acqua in Funzione"
+      }
+    },
+    "button": {
+      "start": {
+        "name": "Avvio"
+      }
+    },
+    "climate": {
+      "climate_zone1": {
+        "name": "Termostato Zona1"
+      },
+      "climate_zone2": {
+        "name": "Termostato Zona2"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "Silenzioso",
+              "full": "Massimo"
+            }
+          }
+        }
+      }
+    },
+    "fan": {
+      "fresh_air": {
+        "name": "Aria Fresca"
+      },
+      "fresh_air_exhaust": {
+        "name": "Estrazione Aria Fresca"
+      }
+    },
+    "lock": {
+      "child_lock": {
+        "name": "Blocco Bambini"
+      }
+    },
+    "number": {
+      "dry_level": {
+        "name": "Livello Asciugatura"
+      },
+      "heating_level": {
+        "name": "Livello Riscaldamento"
+      },
+      "seat_temp_level": {
+        "name": "Livello Temperatura Sedile"
+      },
+      "water_temp_level": {
+        "name": "Livello Temperatura Acqua"
+      },
+      "fan_speed_percent": {
+        "name": "Percentuale Velocità Ventola"
+      },
+      "vacation_days": {
+        "name": "Giorni Vacanza"
+      },
+      "leak_water_protection_value": {
+        "name": "Valore Protezione Perdita Acqua"
+      },
+      "flushing_days": {
+        "name": "Giorni Rigenerazione"
+      },
+      "water_hardness": {
+        "name": "Durezza Acqua"
+      }
+    },
+    "select": {
+      "detect_mode": {
+        "name": "Modalità Rilevamento"
+      },
+      "direction": {
+        "name": "Direzione"
+      },
+      "fan_speed": {
+        "name": "Velocità Ventola"
+      },
+      "fresh_air_exhaust_mode": {
+        "name": "Velocità Estrazione Aria Fresca",
+        "state": {
+          "off": "Spento",
+          "silent": "Bassa",
+          "high": "Alta",
+          "full": "Massima"
+        }
+      },
+      "fresh_air_mode": {
+        "name": "Velocità Aria Fresca",
+        "state": {
+          "off": "Spento",
+          "low": "Bassa",
+          "medium": "Media",
+          "high": "Alta",
+          "full": "Massima"
+        }
+      },
+      "mode": {
+        "name": "Modalità"
+      },
+      "oscillation_angle": {
+        "name": "Angolo Oscillazione"
+      },
+      "oscillation_mode": {
+        "name": "Modalità Oscillazione"
+      },
+      "rate_select": {
+        "name": "Limite Potenza"
+      },
+      "screen_display": {
+        "name": "Display Schermo"
+      },
+      "silent_level": {
+        "name": "Livello Silenzioso"
+      },
+      "tilting_angle": {
+        "name": "Angolo Inclinazione"
+      },
+      "wash_mode": {
+        "name": "Modalità Lavaggio"
+      },
+      "water_level_set": {
+        "name": "Impostazione Livello Acqua"
+      },
+      "wind_lr_angle": {
+        "name": "Flusso Aria Orizzontale",
+        "state": {
+          "off": "Spento",
+          "left": "Sinistra",
+          "left-mid": "Sinistra-Medio",
+          "middle": "Centro",
+          "right-mid": "Destra-Medio",
+          "right": "Destra"
+        }
+      },
+      "wind_ud_angle": {
+        "name": "Flusso Aria Verticale",
+        "state": {
+          "off": "Spento",
+          "up": "Su",
+          "up-mid": "Su-Medio",
+          "middle": "Centro",
+          "down-mid": "Giù-Medio",
+          "down": "Giù"
+        }
+      }
+    },
+    "time": {
+      "timing_regeneration": {
+        "name": "Rigenerazione Programmata"
+      }
+    },
+    "sensor": {
+      "bathing_leaving_temperature": {
+        "name": "Temperatura Acqua in Uscita Bagno"
+      },
+      "bottom_compartment_remaining": {
+        "name": "Tempo Rimanente Scomparto Inferiore"
+      },
+      "bottom_compartment_status": {
+        "name": "Stato Scomparto Inferiore"
+      },
+      "bottom_compartment_temperature": {
+        "name": "Temperatura Scomparto Inferiore"
+      },
+      "bottom_temperature": {
+        "name": "Temperatura Inferiore"
+      },
+      "bright": {
+        "name": "Livello Luminosità"
+      },
+      "compressor_temperature": {
+        "name": "Temperatura Compressore"
+      },
+      "condenser_temperature": {
+        "name": "Temperatura Condensatore"
+      },
+      "current_energy_consumption": {
+        "name": "Consumo Energetico Attuale"
+      },
+      "current_temperature": {
+        "name": "Temperatura Attuale"
+      },
+      "dehydration_speed": {
+        "name": "Velocità Centrifuga"
+      },
+      "dehydration_time": {
+        "name": "Tempo Centrifuga"
+      },
+      "dehydration_time_value": {
+        "name": "Valore Tempo Centrifuga"
+      },
+      "temperature": {
+        "name": "Temperatura"
+      },
+      "wash_time_value": {
+        "name": "Valore Tempo Lavaggio"
+      },
+      "stains": {
+        "name": "Macchie"
+      },
+      "dirty_degree": {
+        "name": "Grado di Sporco"
+      },
+      "detergent": {
+        "name": "Detersivo"
+      },
+      "intensity": {
+        "name": "Intensità"
+      },
+      "dryness_level": {
+        "name": "Livello Asciugatura"
+      },
+      "dry_temperature": {
+        "name": "Temperatura Asciugatura"
+      },
+      "door_warn": {
+        "name": "Avviso Porta"
+      },
+      "ai_switch": {
+        "name": "Interruttore AI"
+      },
+      "material": {
+        "name": "Materiale"
+      },
+      "water_box": {
+        "name": "Serbatoio Acqua"
+      },
+      "energy_consumption": {
+        "name": "Consumo Energetico"
+      },
+      "error": {
+        "name": "Errore",
+        "state": {
+          "no_error": "Nessun Errore",
+          "e1_position_not_found": "E1 Posizione non trovata",
+          "e2_photo_sensor_no_signal": "E2 Nessun segnale dal fotosensore",
+          "e3_motor_not_running": "E3 Motore non in funzione",
+          "e4_wrong_position": "E4 Posizione errata",
+          "e1_motor_fault": "E1 Guasto motore",
+          "e5_communication_fault": "E5 Guasto di comunicazione",
+          "e6_salt_sensor_fault": "E6 Guasto sensore sale",
+          "e7_chlorine_sterilization_fault": "E7 Guasto sterilizzazione al cloro"
+        }
+      },
+      "error_code": {
+        "name": "Codice Errore"
+      },
+      "estimated_energy_consumption": {
+        "name": "Consumo Energetico Stimato"
+      },
+      "estimated_water_consumption": {
+        "name": "Consumo Acqua Stimato"
+      },
+      "fan_level": {
+        "name": "Livello Ventola"
+      },
+      "filter_life": {
+        "name": "Durata Filtro"
+      },
+      "filter1_days": {
+        "name": "Giorni Disponibili Filtro1"
+      },
+      "filter1_life": {
+        "name": "Livello Durata Filtro1"
+      },
+      "filter2_days": {
+        "name": "Giorni Disponibili Filtro2"
+      },
+      "filter2_life": {
+        "name": "Livello Durata Filtro2"
+      },
+      "filter3_days": {
+        "name": "Giorni Disponibili Filtro3"
+      },
+      "filter3_life": {
+        "name": "Livello Durata Filtro3"
+      },
+      "flex_zone_actual_temp": {
+        "name": "Temperatura Attuale Zona Flex"
+      },
+      "flex_zone_setting_temp": {
+        "name": "Temperatura Impostata Zona Flex"
+      },
+      "freezer_actual_temp": {
+        "name": "Temperatura Attuale Freezer"
+      },
+      "freezer_setting_temp": {
+        "name": "Temperatura Impostata Freezer"
+      },
+      "hcho": {
+        "name": "Metanale"
+      },
+      "heating_leaving_temperature": {
+        "name": "Temperatura Acqua in Uscita Riscaldamento"
+      },
+      "heating_power": {
+        "name": "Potenza Riscaldamento"
+      },
+      "heating_time_remaining": {
+        "name": "Tempo Rimanente Riscaldamento"
+      },
+      "in_tds": {
+        "name": "TDS Ingresso"
+      },
+      "indoor_humidity": {
+        "name": "Umidità Interna"
+      },
+      "indoor_temperature": {
+        "name": "Temperatura Interna"
+      },
+      "keep_warm_remaining": {
+        "name": "Tempo Rimanente Mantenimento Caldo"
+      },
+      "keep_warm_time": {
+        "name": "Tempo Mantenimento Caldo"
+      },
+      "left_salt": {
+        "name": "Sale Rimanente"
+      },
+      "middle_compartment_remaining": {
+        "name": "Tempo Rimanente Scomparto Centrale"
+      },
+      "middle_compartment_status": {
+        "name": "Stato Scomparto Centrale"
+      },
+      "middle_compartment_temperature": {
+        "name": "Temperatura Scomparto Centrale"
+      },
+      "mode": {
+        "name": "Modalità"
+      },
+      "out_tds": {
+        "name": "TDS Uscita"
+      },
+      "outdoor_temperature": {
+        "name": "Temperatura Esterna"
+      },
+      "program": {
+        "name": "Programma"
+      },
+      "progress": {
+        "name": "Avanzamento"
+      },
+      "realtime_power": {
+        "name": "Potenza in Tempo Reale"
+      },
+      "pmv": {
+        "name": "PMV"
+      },
+      "refrigerator_actual_temp": {
+        "name": "Temperatura Attuale Frigorifero"
+      },
+      "refrigerator_setting_temp": {
+        "name": "Temperatura Impostata Frigorifero"
+      },
+      "regeneration_left_seconds": {
+        "name": "Secondi Rimanenti Rigenerazione"
+      },
+      "remaining_days": {
+        "name": "Giorni Rimanenti"
+      },
+      "right_flex_zone_actual_temp": {
+        "name": "Temperatura Attuale Zona Flex Destra"
+      },
+      "right_flex_zone_setting_temp": {
+        "name": "Temperatura Impostata Zona Flex Destra"
+      },
+      "rinse_count": {
+        "name": "Numero Risciacqui"
+      },
+      "rinse_level": {
+        "name": "Livello Risciacquo"
+      },
+      "salt_setting": {
+        "name": "Impostazione Sale"
+      },
+      "seat_temperature": {
+        "name": "Temperatura Sedile"
+      },
+      "soak_time": {
+        "name": "Tempo Ammollo"
+      },
+      "soft_available": {
+        "name": "Acqua Addolcita Disponibile"
+      },
+      "softener": {
+        "name": "Ammorbidente"
+      },
+      "softwater": {
+        "name": "Livello Acqua Addolcita"
+      },
+      "status": {
+        "name": "Stato"
+      },
+      "storage_remaining": {
+        "name": "Tempo Rimanente Conservazione"
+      },
+      "tank": {
+        "name": "Serbatoio"
+      },
+      "tank_actual_temperature": {
+        "name": "Temperatura Attuale Serbatoio"
+      },
+      "target_temperature": {
+        "name": "Temperatura Obiettivo"
+      },
+      "time_remaining": {
+        "name": "Tempo Rimanente"
+      },
+      "top_compartment_remaining": {
+        "name": "Tempo Rimanente Scomparto Superiore"
+      },
+      "top_compartment_status": {
+        "name": "Stato Scomparto Superiore"
+      },
+      "top_compartment_temperature": {
+        "name": "Temperatura Scomparto Superiore"
+      },
+      "top_temperature": {
+        "name": "Temperatura Superiore"
+      },
+      "total_energy_consumption": {
+        "name": "Consumo Energetico Totale"
+      },
+      "total_produced_energy": {
+        "name": "Energia Totale Prodotta"
+      },
+      "tvoc": {
+        "name": "TVOC"
+      },
+      "wash_level": {
+        "name": "Numero Risciacqui"
+      },
+      "wash_strength": {
+        "name": "Intensità Lavaggio"
+      },
+      "wash_time": {
+        "name": "Tempo Lavaggio"
+      },
+      "water_consumption": {
+        "name": "Consumo Acqua"
+      },
+      "water_consumption_average": {
+        "name": "Consumo Acqua Medio"
+      },
+      "water_consumption_big": {
+        "name": "Consumo Acqua"
+      },
+      "water_temperature": {
+        "name": "Temperatura Acqua"
+      },
+      "water_level": {
+        "name": "Livello Acqua"
+      },
+      "wind": {
+        "name": "Vento"
+      },
+      "typeinfo": {
+        "name": "Informazioni Tipo"
+      },
+      "use_days": {
+        "name": "Giorni di Utilizzo"
+      },
+      "elec_heat": {
+        "name": "Riscaldamento Elettrico"
+      },
+      "water_pump": {
+        "name": "Pompa Acqua"
+      },
+      "four_way": {
+        "name": "Valvola Quattro Vie"
+      },
+      "back_water": {
+        "name": "Acqua di Ritorno"
+      },
+      "sterilize": {
+        "name": "Sterilizzazione"
+      },
+      "disinfection_temperature": {
+        "name": "Temperatura Disinfezione"
+      },
+      "max_temperature": {
+        "name": "Temperatura Obiettivo Massima"
+      },
+      "vacation_start_year": {
+        "name": "Anno Inizio Vacanza"
+      },
+      "vacation_start_month": {
+        "name": "Mese Inizio Vacanza"
+      },
+      "vacation_start_day": {
+        "name": "Giorno Inizio Vacanza"
+      },
+      "auto_sterilize_week": {
+        "name": "Giorno Sterilizzazione Automatica"
+      },
+      "auto_sterilize_hour": {
+        "name": "Ora Sterilizzazione Automatica"
+      },
+      "auto_sterilize_minute": {
+        "name": "Minuto Sterilizzazione Automatica"
+      },
+      "working_time": {
+        "name": "Tempo di Lavoro"
+      },
+      "humidity": {
+        "name": "Umidità"
+      },
+      "variable_mode": {
+        "name": "Modalità Variabile"
+      },
+      "compressor_frequency": {
+        "name": "Frequenza Compressore"
+      },
+      "target_compressor_frequency": {
+        "name": "Frequenza Obiettivo Compressore"
+      },
+      "compressor_current": {
+        "name": "Corrente Compressore"
+      },
+      "compressor_voltage": {
+        "name": "Tensione Compressore"
+      },
+      "compressor_power": {
+        "name": "Potenza Compressore"
+      },
+      "indoor_coil_temperature": {
+        "name": "Temperatura Batteria Interna (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "Temperatura Evaporatore (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "Temperatura Ambiente Esterna (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Temperatura Tubo di Scarico (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "Velocità Ventola Interna"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Velocità Obiettivo Ventola Interna"
+      },
+      "velocity": {
+        "name": "Velocità"
+      }
+    },
+    "switch": {
+      "anion": {
+        "name": "Anioni"
+      },
+      "aux_heating": {
+        "name": "Riscaldamento Ausiliario"
+      },
+      "boost_mode": {
+        "name": "Modalità Boost"
+      },
+      "breezeless": {
+        "name": "Senza Corrente d’Aria"
+      },
+      "child_lock": {
+        "name": "Blocco Bambini"
+      },
+      "cl_sterilization": {
+        "name": "Sterilizzazione al Cloro"
+      },
+      "comfort_mode": {
+        "name": "Modalità Comfort"
+      },
+      "dhw_power": {
+        "name": "Potenza ACS"
+      },
+      "disinfect": {
+        "name": "Disinfezione"
+      },
+      "vacation_mode": {
+        "name": "Modalità Vacanza"
+      },
+      "dry": {
+        "name": "Asciugatura"
+      },
+      "cold_water_single": {
+        "name": "Acqua Fredda Singola"
+      },
+      "cold_water_dot": {
+        "name": "Acqua Fredda Punto"
+      },
+      "eco_mode": {
+        "name": "Modalità ECO"
+      },
+      "memory": {
+        "name": "Memo U"
+      },
+      "fast_dhw": {
+        "name": "ACS Rapida"
+      },
+      "foam_shield": {
+        "name": "Protezione Schiuma"
+      },
+      "frost_protect": {
+        "name": "Protezione Gelo"
+      },
+      "heating_power": {
+        "name": "Potenza Riscaldamento"
+      },
+      "indirect_wind": {
+        "name": "Vento Indiretto"
+      },
+      "leak_water_protection": {
+        "name": "Protezione Perdita Acqua"
+      },
+      "light": {
+        "name": "Luce"
+      },
+      "link_to_ac": {
+        "name": "Collegamento al Climatizzatore"
+      },
+      "main_light": {
+        "name": "Luce Principale"
+      },
+      "main_power": {
+        "name": "Alimentazione Principale"
+      },
+      "natural_wind": {
+        "name": "Vento Naturale"
+      },
+      "night_light": {
+        "name": "Luce Notturna"
+      },
+      "oscillate": {
+        "name": "Oscillazione"
+      },
+      "power": {
+        "name": "Alimentazione"
+      },
+      "powerful_purify": {
+        "name": "Purificazione Potente"
+      },
+      "prompt_tone": {
+        "name": "Tono Avviso"
+      },
+      "regeneration": {
+        "name": "Rigenerazione"
+      },
+      "water_pump": {
+        "name": "Pompa Acqua"
+      },
+      "water_way": {
+        "name": "Circuito Acqua"
+      },
+      "screen_display": {
+        "name": "Display Schermo"
+      },
+      "screen_display_alternate": {
+        "name": "Display Schermo Alternato"
+      },
+      "sensor_light": {
+        "name": "Luce Sensore"
+      },
+      "silent_mode": {
+        "name": "Modalità Silenziosa"
+      },
+      "sleep_mode": {
+        "name": "Modalità Sonno"
+      },
+      "out_silent": {
+        "name": "Modalità Silenziosa Esterna"
+      },
+      "smart_eye": {
+        "name": "Occhio Intelligente"
+      },
+      "smart_volume": {
+        "name": "Volume Intelligente"
+      },
+      "smelly_sensor": {
+        "name": "Sensore Odori"
+      },
+      "soften": {
+        "name": "Addolcimento"
+      },
+      "standby": {
+        "name": "Standby"
+      },
+      "start": {
+        "name": "Avvio"
+      },
+      "sterilization": {
+        "name": "Sterilizzazione"
+      },
+      "storage": {
+        "name": "Conservazione"
+      },
+      "swing": {
+        "name": "Oscillazione"
+      },
+      "swing_horizontal": {
+        "name": "Oscillazione Orizzontale"
+      },
+      "swing_vertical": {
+        "name": "Oscillazione Verticale"
+      },
+      "self_clean": {
+        "name": "Autopulizia"
+      },
+      "sound": {
+        "name": "Suono"
+      },
+      "tbh": {
+        "name": "TBH"
+      },
+      "variable_heating": {
+        "name": "Riscaldamento Variabile"
+      },
+      "ventilation": {
+        "name": "Ventilazione"
+      },
+      "whole_tank_heating": {
+        "name": "Riscaldamento Intero Serbatoio"
+      },
+      "zero_cold_pulse": {
+        "name": "Acqua Zero Fredda (Impulso)"
+      },
+      "zero_cold_water": {
+        "name": "Acqua Zero Fredda"
+      },
+      "zone1_curve": {
+        "name": "Curva Zona1"
+      },
+      "zone1_power": {
+        "name": "Potenza Zona1"
+      },
+      "zone2_curve": {
+        "name": "Curva Zona2"
+      },
+      "zone2_power": {
+        "name": "Potenza Zona2"
+      }
+    },
+    "water_heater": {
+      "domestic_hot_water": {
+        "name": "Acqua calda sanitaria"
+      },
+      "bathing": {
+        "name": "Bagno"
+      },
+      "heating": {
+        "name": "Riscaldamento"
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "ip_address": "Indirizzo IP",
+          "refresh_interval": "Intervallo aggiornamento (0 significa nessun aggiornamento attivo)",
+          "sensors": "Sensori aggiuntivi",
+          "switches": "Controlli aggiuntivi",
+          "customize": "Personalizza"
+        },
+        "title": "Configura"
+      }
+    },
+    "abort": {
+      "account_option": "L’account non supporta questa operazione.\nClicca \"AGGIUNGI DISPOSITIVO\" per aggiungere un nuovo dispositivo."
+    }
+  },
+  "services": {
+    "set_attribute": {
+      "name": "Imposta attributo",
+      "description": "Imposta il valore dell’attributo del dispositivo",
+      "fields": {
+        "device_id": {
+          "name": "Codice elettrodomestico",
+          "description": "Il codice elettrodomestico (ID dispositivo) dell’elettrodomestico"
+        },
+        "attribute": {
+          "name": "Attributo",
+          "description": "Il nome dell’attributo da impostare"
+        },
+        "value": {
+          "name": "Valore",
+          "description": "Il valore dell’attributo da impostare"
+        }
+      }
+    },
+    "send_command": {
+      "name": "Comando personalizzato",
+      "description": "Invia un comando personalizzato al dispositivo",
+      "fields": {
+        "device_id": {
+          "name": "Codice elettrodomestico",
+          "description": "Il codice elettrodomestico (ID dispositivo) dell’elettrodomestico"
+        },
+        "cmd_type": {
+          "name": "Tipo di comando",
+          "description": "Il tipo di comando, deve essere 3 (query) o 2 (set)"
+        },
+        "cmd_body": {
+          "name": "Corpo del comando",
+          "description": "Il corpo del comando (non include l’intestazione del protocollo MSmart e il checksum finale)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/midea_ac_lan/translations/ru.json
+++ b/custom_components/midea_ac_lan/translations/ru.json
@@ -144,6 +144,21 @@
       "middle_compartment_preheating": {
         "name": "Middle Compartment Preheating"
       },
+      "top_elec_heat": {
+        "name": "Верхний электронагрев"
+      },
+      "bottom_elec_heat": {
+        "name": "Нижний электронагрев"
+      },
+      "mute_effect": {
+        "name": "Эффект тихого режима"
+      },
+      "mute_status": {
+        "name": "Статус тихого режима"
+      },
+      "multi_terminal": {
+        "name": "Мультитерминал"
+      },
       "oilcup_full": {
         "name": "Oil-cup Full"
       },
@@ -167,6 +182,24 @@
       },
       "seat_status": {
         "name": "Сиденье"
+      },
+      "smart_grid": {
+        "name": "Умная сеть"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "Напоминание об обслуживании"
+      },
+      "maintain_warn": {
+        "name": "Предупреждение об обслуживании"
+      },
+      "order1_effect": {
+        "name": "Расписание 1 активно"
+      },
+      "order2_effect": {
+        "name": "Расписание 2 активно"
       },
       "status_dhw": {
         "name": "DHW status"
@@ -215,6 +248,20 @@
       },
       "zone2_water_temp_mode": {
         "name": "Zone2 Water-temperature Mode"
+      },
+      "microcrystal_fresh": {
+        "name": "Микрокристаллическая свежесть"
+      },
+      "electronic_smell": {
+        "name": "Дезодорация и стерилизация"
+      },
+      "water_pump_running": {
+        "name": "Работа водяного насоса"
+      }
+    },
+    "button": {
+      "start": {
+        "name": "Старт"
       }
     },
     "climate": {
@@ -223,11 +270,24 @@
       },
       "climate_zone2": {
         "name": "Zone2 Thermostat"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "Тихий",
+              "full": "Полная"
+            }
+          }
+        }
       }
     },
     "fan": {
       "fresh_air": {
         "name": "Fresh Air"
+      },
+      "fresh_air_exhaust": {
+        "name": "Вытяжка свежего воздуха"
       }
     },
     "lock": {
@@ -248,6 +308,12 @@
       "water_temp_level": {
         "name": "Water Temperature Level"
       },
+      "fan_speed_percent": {
+        "name": "Скорость вентилятора (%)"
+      },
+      "vacation_days": {
+        "name": "Дни отпуска"
+      },
       "leak_water_protection_value": {
         "name": "Значение защиты от протечек"
       },
@@ -267,6 +333,25 @@
       },
       "fan_speed": {
         "name": "Скорость"
+      },
+      "fresh_air_exhaust_mode": {
+        "name": "Скорость вытяжки свежего воздуха",
+        "state": {
+          "off": "Выкл",
+          "silent": "Низкая",
+          "high": "Высокая",
+          "full": "Максимальная"
+        }
+      },
+      "fresh_air_mode": {
+        "name": "Скорость свежего воздуха",
+        "state": {
+          "off": "Выкл",
+          "low": "Низкая",
+          "medium": "Средняя",
+          "high": "Высокая",
+          "full": "Максимальная"
+        }
       },
       "mode": {
         "name": "Режим"
@@ -289,8 +374,33 @@
       "tilting_angle": {
         "name": "Угол поворота"
       },
+      "wash_mode": {
+        "name": "Режим мойки"
+      },
       "water_level_set": {
         "name": "Water Level Setting"
+      },
+      "wind_lr_angle": {
+        "name": "Горизонтальный поток воздуха",
+        "state": {
+          "off": "Выкл",
+          "left": "Влево",
+          "left-mid": "Влево-центр",
+          "middle": "Центр",
+          "right-mid": "Вправо-центр",
+          "right": "Вправо"
+        }
+      },
+      "wind_ud_angle": {
+        "name": "Вертикальный поток воздуха",
+        "state": {
+          "off": "Выкл",
+          "up": "Вверх",
+          "up-mid": "Вверх-центр",
+          "middle": "Центр",
+          "down-mid": "Вниз-центр",
+          "down": "Вниз"
+        }
       }
     },
     "time": {
@@ -393,6 +503,12 @@
       },
       "error_code": {
         "name": "Код ошибки"
+      },
+      "estimated_energy_consumption": {
+        "name": "Расчётное энергопотребление"
+      },
+      "estimated_water_consumption": {
+        "name": "Расчётный расход воды"
       },
       "fan_level": {
         "name": "Fan level"
@@ -571,11 +687,8 @@
       "tvoc": {
         "name": "TVOC"
       },
-      "use_days": {
-        "name": "Дни использования"
-      },
-      "velocity": {
-        "name": "Скорость"
+      "wash_level": {
+        "name": "Количество полосканий"
       },
       "wash_strength": {
         "name": "Wash strength"
@@ -598,8 +711,98 @@
       "water_level": {
         "name": "Уровень воды"
       },
+      "wind": {
+        "name": "Поток воздуха"
+      },
+      "typeinfo": {
+        "name": "Информация о типе"
+      },
+      "use_days": {
+        "name": "Дни использования"
+      },
+      "elec_heat": {
+        "name": "Электронагрев"
+      },
+      "water_pump": {
+        "name": "Водяной насос"
+      },
+      "four_way": {
+        "name": "Четырёхходовой клапан"
+      },
+      "back_water": {
+        "name": "Обратная вода"
+      },
+      "sterilize": {
+        "name": "Стерилизация"
+      },
+      "disinfection_temperature": {
+        "name": "Температура дезинфекции"
+      },
+      "max_temperature": {
+        "name": "Максимальная целевая температура"
+      },
+      "vacation_start_year": {
+        "name": "Год начала отпуска"
+      },
+      "vacation_start_month": {
+        "name": "Месяц начала отпуска"
+      },
+      "vacation_start_day": {
+        "name": "День начала отпуска"
+      },
+      "auto_sterilize_week": {
+        "name": "День недели автостерилизации"
+      },
+      "auto_sterilize_hour": {
+        "name": "Час автостерилизации"
+      },
+      "auto_sterilize_minute": {
+        "name": "Минута автостерилизации"
+      },
       "working_time": {
         "name": "Время работы"
+      },
+      "humidity": {
+        "name": "Влажность"
+      },
+      "variable_mode": {
+        "name": "Переменный режим"
+      },
+      "compressor_frequency": {
+        "name": "Частота компрессора"
+      },
+      "target_compressor_frequency": {
+        "name": "Целевая частота компрессора"
+      },
+      "compressor_current": {
+        "name": "Ток компрессора"
+      },
+      "compressor_voltage": {
+        "name": "Напряжение компрессора"
+      },
+      "compressor_power": {
+        "name": "Мощность компрессора"
+      },
+      "indoor_coil_temperature": {
+        "name": "Температура внутреннего теплообменника (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "Температура испарителя (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "Наружная температура окружающей среды (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Температура нагнетательной трубы (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "Скорость внутреннего вентилятора"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Целевая скорость внутреннего вентилятора"
+      },
+      "velocity": {
+        "name": "Скорость"
       }
     },
     "switch": {
@@ -630,11 +833,23 @@
       "disinfect": {
         "name": "Дезинфекция"
       },
+      "vacation_mode": {
+        "name": "Режим отпуска"
+      },
       "dry": {
         "name": "Dry"
       },
+      "cold_water_single": {
+        "name": "Холодная вода (однократно)"
+      },
+      "cold_water_dot": {
+        "name": "Холодная вода (порционно)"
+      },
       "eco_mode": {
         "name": "Эко-режим"
+      },
+      "memory": {
+        "name": "Memo U"
       },
       "fast_dhw": {
         "name": "Fast DHW"
@@ -708,6 +923,9 @@
       "sleep_mode": {
         "name": "Sleep Mode"
       },
+      "out_silent": {
+        "name": "Тихий режим наружного блока"
+      },
       "smart_eye": {
         "name": "Smart Eye"
       },
@@ -725,6 +943,9 @@
       },
       "start": {
         "name": "Старт"
+      },
+      "sterilization": {
+        "name": "Стерилизация"
       },
       "storage": {
         "name": "Storage"

--- a/custom_components/midea_ac_lan/translations/sk.json
+++ b/custom_components/midea_ac_lan/translations/sk.json
@@ -144,6 +144,21 @@
       "middle_compartment_preheating": {
         "name": "Middle Compartment Preheating"
       },
+      "top_elec_heat": {
+        "name": "Horné elektrické vykurovanie"
+      },
+      "bottom_elec_heat": {
+        "name": "Dolné elektrické vykurovanie"
+      },
+      "mute_effect": {
+        "name": "Účinok stíšenia"
+      },
+      "mute_status": {
+        "name": "Stav stíšenia"
+      },
+      "multi_terminal": {
+        "name": "Viacero terminálov"
+      },
       "oilcup_full": {
         "name": "Oil-cup Full"
       },
@@ -167,6 +182,24 @@
       },
       "seat_status": {
         "name": "Seat Status"
+      },
+      "smart_grid": {
+        "name": "Inteligentná sieť"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "Pripomienka údržby"
+      },
+      "maintain_warn": {
+        "name": "Upozornenie na údržbu"
+      },
+      "order1_effect": {
+        "name": "Plán 1 aktívny"
+      },
+      "order2_effect": {
+        "name": "Plán 2 aktívny"
       },
       "status_dhw": {
         "name": "DHW status"
@@ -215,6 +248,20 @@
       },
       "zone2_water_temp_mode": {
         "name": "Zone2 Water-temperature Mode"
+      },
+      "microcrystal_fresh": {
+        "name": "Mikrokryštalická sviežosť"
+      },
+      "electronic_smell": {
+        "name": "Dezodorácia a sterilizácia"
+      },
+      "water_pump_running": {
+        "name": "Vodné čerpadlo beží"
+      }
+    },
+    "button": {
+      "start": {
+        "name": "Štart"
       }
     },
     "climate": {
@@ -223,11 +270,24 @@
       },
       "climate_zone2": {
         "name": "Zone2 Thermostat"
+      },
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "Tichý",
+              "full": "Plný"
+            }
+          }
+        }
       }
     },
     "fan": {
       "fresh_air": {
         "name": "Fresh Air"
+      },
+      "fresh_air_exhaust": {
+        "name": "Odvod čerstvého vzduchu"
       }
     },
     "lock": {
@@ -248,6 +308,12 @@
       "water_temp_level": {
         "name": "Water Temperature Level"
       },
+      "fan_speed_percent": {
+        "name": "Percento rýchlosti ventilátora"
+      },
+      "vacation_days": {
+        "name": "Dni dovolenky"
+      },
       "leak_water_protection_value": {
         "name": "Hodnota ochrany proti úniku vody"
       },
@@ -267,6 +333,25 @@
       },
       "fan_speed": {
         "name": "Fan Speed"
+      },
+      "fresh_air_exhaust_mode": {
+        "name": "Rýchlosť odvodu čerstvého vzduchu",
+        "state": {
+          "off": "Vypnuté",
+          "silent": "Nízka",
+          "high": "Vysoká",
+          "full": "Plná"
+        }
+      },
+      "fresh_air_mode": {
+        "name": "Rýchlosť čerstvého vzduchu",
+        "state": {
+          "off": "Vypnuté",
+          "low": "Nízka",
+          "medium": "Stredná",
+          "high": "Vysoká",
+          "full": "Plná"
+        }
       },
       "mode": {
         "name": "Mode"
@@ -289,8 +374,33 @@
       "tilting_angle": {
         "name": "Tilting Angle"
       },
+      "wash_mode": {
+        "name": "Režim prania"
+      },
       "water_level_set": {
         "name": "Water Level Setting"
+      },
+      "wind_lr_angle": {
+        "name": "Vodorovné prúdenie vzduchu",
+        "state": {
+          "off": "Vypnuté",
+          "left": "Vľavo",
+          "left-mid": "Vľavo-stred",
+          "middle": "Stred",
+          "right-mid": "Vpravo-stred",
+          "right": "Vpravo"
+        }
+      },
+      "wind_ud_angle": {
+        "name": "Zvislé prúdenie vzduchu",
+        "state": {
+          "off": "Vypnuté",
+          "up": "Hore",
+          "up-mid": "Hore-stred",
+          "middle": "Stred",
+          "down-mid": "Dole-stred",
+          "down": "Dole"
+        }
       }
     },
     "time": {
@@ -335,8 +445,44 @@
       "dehydration_time": {
         "name": "dehydration time"
       },
+      "dehydration_time_value": {
+        "name": "Hodnota času odstreďovania"
+      },
+      "temperature": {
+        "name": "Teplota"
+      },
+      "wash_time_value": {
+        "name": "Hodnota času prania"
+      },
+      "stains": {
+        "name": "Škvrny"
+      },
+      "dirty_degree": {
+        "name": "Stupeň znečistenia"
+      },
       "detergent": {
         "name": "detergent"
+      },
+      "intensity": {
+        "name": "Intenzita"
+      },
+      "dryness_level": {
+        "name": "Úroveň suchosti"
+      },
+      "dry_temperature": {
+        "name": "Teplota sušenia"
+      },
+      "door_warn": {
+        "name": "Upozornenie na dvere"
+      },
+      "ai_switch": {
+        "name": "AI prepínač"
+      },
+      "material": {
+        "name": "Materiál"
+      },
+      "water_box": {
+        "name": "Nádržka na vodu"
       },
       "energy_consumption": {
         "name": "Energy Consumption"
@@ -357,6 +503,12 @@
       },
       "error_code": {
         "name": "Error Code"
+      },
+      "estimated_energy_consumption": {
+        "name": "Odhadovaná spotreba energie"
+      },
+      "estimated_water_consumption": {
+        "name": "Odhadovaná spotreba vody"
       },
       "fan_level": {
         "name": "Fan level"
@@ -511,9 +663,6 @@
       "target_temperature": {
         "name": "Target Temperature"
       },
-      "temperature": {
-        "name": "Teplota"
-      },
       "time_remaining": {
         "name": "Time Remaining"
       },
@@ -537,12 +686,6 @@
       },
       "tvoc": {
         "name": "TVOC"
-      },
-      "use_days": {
-        "name": "Dni používania"
-      },
-      "velocity": {
-        "name": "Rýchlosť"
       },
       "wash_level": {
         "name": "rinse count"
@@ -568,8 +711,98 @@
       "water_level": {
         "name": "Water Level"
       },
+      "wind": {
+        "name": "Vietor"
+      },
+      "typeinfo": {
+        "name": "Informácie o type"
+      },
+      "use_days": {
+        "name": "Dni používania"
+      },
+      "elec_heat": {
+        "name": "Elektrické vykurovanie"
+      },
+      "water_pump": {
+        "name": "Vodné čerpadlo"
+      },
+      "four_way": {
+        "name": "Štvorcestný ventil"
+      },
+      "back_water": {
+        "name": "Spätná voda"
+      },
+      "sterilize": {
+        "name": "Sterilizácia"
+      },
+      "disinfection_temperature": {
+        "name": "Teplota dezinfekcie"
+      },
+      "max_temperature": {
+        "name": "Maximálna cieľová teplota"
+      },
+      "vacation_start_year": {
+        "name": "Rok začiatku dovolenky"
+      },
+      "vacation_start_month": {
+        "name": "Mesiac začiatku dovolenky"
+      },
+      "vacation_start_day": {
+        "name": "Deň začiatku dovolenky"
+      },
+      "auto_sterilize_week": {
+        "name": "Týždeň automatickej sterilizácie"
+      },
+      "auto_sterilize_hour": {
+        "name": "Hodina automatickej sterilizácie"
+      },
+      "auto_sterilize_minute": {
+        "name": "Minúta automatickej sterilizácie"
+      },
       "working_time": {
         "name": "Working Time"
+      },
+      "humidity": {
+        "name": "Vlhkosť"
+      },
+      "variable_mode": {
+        "name": "Variabilný režim"
+      },
+      "compressor_frequency": {
+        "name": "Frekvencia kompresora"
+      },
+      "target_compressor_frequency": {
+        "name": "Cieľová frekvencia kompresora"
+      },
+      "compressor_current": {
+        "name": "Prúd kompresora"
+      },
+      "compressor_voltage": {
+        "name": "Napätie kompresora"
+      },
+      "compressor_power": {
+        "name": "Výkon kompresora"
+      },
+      "indoor_coil_temperature": {
+        "name": "Teplota vnútorného výmenníka (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "Teplota výparníka (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "Vonkajšia teplota okolia (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Teplota výtlačného potrubia (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "Rýchlosť vnútorného ventilátora"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Cieľová rýchlosť vnútorného ventilátora"
+      },
+      "velocity": {
+        "name": "Rýchlosť"
       }
     },
     "switch": {
@@ -600,11 +833,23 @@
       "disinfect": {
         "name": "Disinfect"
       },
+      "vacation_mode": {
+        "name": "Režim dovolenky"
+      },
       "dry": {
         "name": "Dry"
       },
+      "cold_water_single": {
+        "name": "Studená voda jednorazovo"
+      },
+      "cold_water_dot": {
+        "name": "Studená voda bodovo"
+      },
       "eco_mode": {
         "name": "ECO Mode"
+      },
+      "memory": {
+        "name": "Memo U"
       },
       "fast_dhw": {
         "name": "Fast DHW"
@@ -678,6 +923,9 @@
       "sleep_mode": {
         "name": "Sleep Mode"
       },
+      "out_silent": {
+        "name": "Vonkajší tichý režim"
+      },
       "smart_eye": {
         "name": "Smart Eye"
       },
@@ -695,6 +943,9 @@
       },
       "start": {
         "name": "Start"
+      },
+      "sterilization": {
+        "name": "Sterilizácia"
       },
       "storage": {
         "name": "Storage"

--- a/custom_components/midea_ac_lan/translations/zh-Hans.json
+++ b/custom_components/midea_ac_lan/translations/zh-Hans.json
@@ -144,6 +144,21 @@
       "middle_compartment_preheating": {
         "name": "中层预热"
       },
+      "top_elec_heat": {
+        "name": "顶部电加热"
+      },
+      "bottom_elec_heat": {
+        "name": "底部电加热"
+      },
+      "mute_effect": {
+        "name": "静音效果"
+      },
+      "mute_status": {
+        "name": "静音状态"
+      },
+      "multi_terminal": {
+        "name": "多终端"
+      },
       "oilcup_full": {
         "name": "油杯满提示"
       },
@@ -167,6 +182,24 @@
       },
       "seat_status": {
         "name": "入座状态"
+      },
+      "smart_grid": {
+        "name": "智能电网"
+      },
+      "eco": {
+        "name": "ECO"
+      },
+      "maintenance_reminder": {
+        "name": "维护提醒"
+      },
+      "maintain_warn": {
+        "name": "维护警告"
+      },
+      "order1_effect": {
+        "name": "定时1生效"
+      },
+      "order2_effect": {
+        "name": "定时2生效"
       },
       "status_dhw": {
         "name": "DHW状态"
@@ -221,6 +254,9 @@
       },
       "electronic_smell": {
         "name": "净味杀菌"
+      },
+      "water_pump_running": {
+        "name": "水泵运行"
       }
     },
     "button": {
@@ -274,6 +310,9 @@
       },
       "fan_speed_percent": {
         "name": "风速百分比"
+      },
+      "vacation_days": {
+        "name": "假期天数"
       },
       "leak_water_protection_value": {
         "name": "漏水保护阈值"
@@ -420,6 +459,9 @@
       },
       "dirty_degree": {
         "name": "脏度"
+      },
+      "detergent": {
+        "name": "洗涤剂"
       },
       "intensity": {
         "name": "强度"
@@ -645,9 +687,6 @@
       "tvoc": {
         "name": "TVOC"
       },
-      "use_days": {
-        "name": "使用天数"
-      },
       "wash_level": {
         "name": "洗涤档位"
       },
@@ -656,9 +695,6 @@
       },
       "wash_time": {
         "name": "洗涤时间档位"
-      },
-      "detergent": {
-        "name": "洗涤剂"
       },
       "water_consumption": {
         "name": "总耗水量"
@@ -669,11 +705,59 @@
       "water_consumption_big": {
         "name": "总耗水量"
       },
+      "water_temperature": {
+        "name": "水温"
+      },
       "water_level": {
         "name": "水位"
       },
-      "water_temperature": {
-        "name": "水温"
+      "wind": {
+        "name": "风"
+      },
+      "typeinfo": {
+        "name": "类型信息"
+      },
+      "use_days": {
+        "name": "使用天数"
+      },
+      "elec_heat": {
+        "name": "电加热"
+      },
+      "water_pump": {
+        "name": "水泵"
+      },
+      "four_way": {
+        "name": "四通阀"
+      },
+      "back_water": {
+        "name": "回水"
+      },
+      "sterilize": {
+        "name": "杀菌"
+      },
+      "disinfection_temperature": {
+        "name": "消毒温度"
+      },
+      "max_temperature": {
+        "name": "最高目标温度"
+      },
+      "vacation_start_year": {
+        "name": "假期开始年"
+      },
+      "vacation_start_month": {
+        "name": "假期开始月"
+      },
+      "vacation_start_day": {
+        "name": "假期开始日"
+      },
+      "auto_sterilize_week": {
+        "name": "自动杀菌星期"
+      },
+      "auto_sterilize_hour": {
+        "name": "自动杀菌小时"
+      },
+      "auto_sterilize_minute": {
+        "name": "自动杀菌分钟"
       },
       "working_time": {
         "name": "工作时间"
@@ -683,6 +767,39 @@
       },
       "variable_mode": {
         "name": "变温区模式"
+      },
+      "compressor_frequency": {
+        "name": "压缩机频率"
+      },
+      "target_compressor_frequency": {
+        "name": "目标压缩机频率"
+      },
+      "compressor_current": {
+        "name": "压缩机电流"
+      },
+      "compressor_voltage": {
+        "name": "压缩机电压"
+      },
+      "compressor_power": {
+        "name": "压缩机功率"
+      },
+      "indoor_coil_temperature": {
+        "name": "室内盘管温度 (T1)"
+      },
+      "evaporator_temperature": {
+        "name": "蒸发器温度 (T2)"
+      },
+      "outdoor_ambient_temperature": {
+        "name": "室外环境温度 (T4)"
+      },
+      "discharge_pipe_temperature": {
+        "name": "排气管温度 (TP)"
+      },
+      "indoor_fan_speed": {
+        "name": "室内风机转速"
+      },
+      "target_indoor_fan_speed": {
+        "name": "目标室内风机转速"
       },
       "velocity": {
         "name": "流速"
@@ -710,23 +827,29 @@
       "comfort_mode": {
         "name": "舒省模式"
       },
-      "cold_water_single": {
-        "name": "单次零冷水"
-      },
-      "cold_water_dot": {
-        "name": "点动零冷水"
-      },
       "dhw_power": {
         "name": "生活热水电源开关"
       },
       "disinfect": {
         "name": "消毒"
       },
+      "vacation_mode": {
+        "name": "假期模式"
+      },
       "dry": {
         "name": "干燥"
       },
+      "cold_water_single": {
+        "name": "单次零冷水"
+      },
+      "cold_water_dot": {
+        "name": "点动零冷水"
+      },
       "eco_mode": {
         "name": "ECO模式"
+      },
+      "memory": {
+        "name": "记忆"
       },
       "fast_dhw": {
         "name": "快速生活热水"
@@ -738,8 +861,7 @@
         "name": "防霜冻"
       },
       "heating_power": {
-        "name": "加热",
-        "_comments": "E2 加热功率, E6 加热开关"
+        "name": "加热"
       },
       "indirect_wind": {
         "name": "防直吹"
@@ -821,6 +943,9 @@
       },
       "start": {
         "name": "启动"
+      },
+      "sterilization": {
+        "name": "杀菌"
       },
       "storage": {
         "name": "保管开关"


### PR DESCRIPTION
## Summary

Synchronizes every `translations/*.json` file against the device registry
(`midea_devices.py`) and the `en.json` base so all **8 locales now share an
identical key structure — 380 leaf keys each, 0 missing / 0 extra**.

The sync was driven from `midea_devices.py` as the ground truth: every
`(platform, translation_key)` pair that defines a `translation_key` was
cross-checked against each locale. This surfaced gaps in `en.json` itself,
not just the other locales.

## `en.json` (base) corrections

`en.json` was missing two entity names that **the registry defines and that
several other locales already had**:

| Key | Value | Notes |
|-----|-------|-------|
| `binary_sensor.zone2_water_temp_mode.name` | `Zone2 Water-temperature Mode` | sibling of the existing zone1/zone2 room + zone1 water modes |
| `sensor.wash_level.name` | `Rinse count` | matches the registry `name` for `DAAttributes.wash_level` |

## `zh-Hans.json`

- Removed a stray non-key annotation: `entity.switch.heating_power._comments`
  (it was a developer note, not a translation string).
- Added the 42 previously-missing entity names in native Simplified Chinese,
  consistent with the file's existing terminology.

## `de` / `es` / `fr` / `hu` / `ru` / `sk`

- Filled every missing entity name with **real, native translations**
  (61–93 strings per locale), matching each file's existing terminology.
- Technical sensor suffixes `(T1)` `(T2)` `(T4)` `(TP)` and product/acronym
  labels (`ECO`, `Memo U`) are preserved verbatim.
- Home Assistant already falls back to `en.json` for any missing key, so these
  additions change displayed text only where a real translation now exists —
  no runtime/structural risk.

## `.pre-commit-config.yaml`

- Added `hu.json` to the existing `codespell` exclude, matching the current
  `de|es|fr` precedent. Hungarian **pont** ("Cold Water Dot") is a codespell
  false positive (flagged as `point`). `ru`/`sk`/`zh-Hans` remain checked and
  are clean.

## Per-locale key counts

| Locale | Before | After | Added |
|--------|-------:|------:|------:|
| en (base) | 378 | 380 | +2 |
| zh-Hans | 339 (+1 stray) | 380 | +42, −1 stray |
| de | 287 | 380 | +93 |
| es | 319 | 380 | +61 |
| fr | 289 | 380 | +91 |
| hu | 287 | 380 | +93 |
| ru | 297 | 380 | +83 |
| sk | 287 | 380 | +93 |

## Verification

- All 8 files are valid JSON and pass `prettier --tab-width 2`.
- `codespell` (same args as CI) is clean on the non-excluded locales
  (`en` / `ru` / `sk` / `zh-Hans`).
- `commitlint` + `commitizen` pass (Conventional Commit).
- No Python changed; ruff/mypy/pylint are unaffected.

## Notes for review

Please sanity-check the native translations for your language(s). A few terms
the translators flagged as judgment calls: `cold_water_single` /
`cold_water_dot` (ambiguous source labels), `microcrystal_fresh` (marketing
name kept literal), and `back_water` (interpreted as recirculation/return
water).
