### PR TITLE
fix(migration): honor IP override and guard discovery in mac/sn backfill

### DIFF
--- a/custom_components/midea_ac_lan/__init__.py
+++ b/custom_components/midea_ac_lan/__init__.py
@@ -360,13 +360,29 @@ async def _async_backfill_mac_and_sn(
         return True
     if config_entry.data.get(CONF_MAC) or config_entry.data.get(CONF_SN):
         return True
-    ip_address = config_entry.data.get(CONF_IP_ADDRESS)
+    # Honor an IP override set via the options flow (e.g. after a DHCP change),
+    # mirroring async_setup_entry; the data IP may be stale.
+    ip_address = config_entry.options.get(CONF_IP_ADDRESS)
+    if ip_address is None:
+        ip_address = config_entry.data.get(CONF_IP_ADDRESS)
     device_id = config_entry.data.get(CONF_DEVICE_ID)
     if ip_address is None or device_id is None:
         return True
-    found_devices = await hass.async_add_executor_job(
-        lambda: discover(ip_address=ip_address),
-    )
+    try:
+        found_devices = await hass.async_add_executor_job(
+            lambda: discover(ip_address=ip_address),
+        )
+    except Exception:
+        # Best-effort migration: any discovery failure (socket error, malformed
+        # reply from a legacy device, parse error) must not break entry setup.
+        # Retry on the next start instead.
+        _LOGGER.debug(
+            "Discovery for device %s failed; mac/serial number migration"
+            " will be retried on next start",
+            device_id,
+            exc_info=True,
+        )
+        return False
     device = found_devices.get(int(device_id))
     if device is None:
         return False


### PR DESCRIPTION
## Summary

A maximum-effort code review of `custom_components/midea_ac_lan/__init__.py` (the 2.1→2.2 mac/serial-number backfill migration added in the recent diagnostics work) surfaced two confirmed defects in `_async_backfill_mac_and_sn`. This PR applies both fixes. No behavior changes outside that one helper.

## Fixes in this PR

### 1. Honor the options-flow IP override (stale-IP → doomed re-discovery every boot)

The backfill read the target IP only from `config_entry.data[CONF_IP_ADDRESS]`, ignoring an override set through the options flow (the options flow writes IP into `options`, not `data`). For a device whose data IP is stale — e.g. after a DHCP lease change — discovery was aimed at a dead address and could **never** succeed. Because the migration returns `False` on a miss and is retried on every startup, this meant a doomed 5-second discovery burned on **every** Home Assistant start, and the mac/sn would never backfill even though the user had corrected the IP in options.

**Fix:** mirror `async_setup_entry` — prefer `config_entry.options.get(CONF_IP_ADDRESS)`, fall back to `config_entry.data.get(CONF_IP_ADDRESS)`.

### 2. Guard `discover()` so a failure can't abort entry loading

`discover()` was called unguarded from inside `async_migrate_entry`. Its parse path can raise `ElementMissing` / `UnicodeDecodeError` / `KeyError` / `IndexError` (malformed reply from a legacy device), and its socket path can raise `OSError`. Any of these would escape `async_migrate_entry` and **abort loading the config entry** — directly contradicting the helper's own docstring contract that the backfill is *best-effort* and *"retried on next start."* A single flaky/legacy device on the network could brick entry setup.

**Fix:** wrap the `discover()` call in `try/except`, log at debug with a traceback (`exc_info=True`), and `return False` so the entry still loads and the migration is retried on the next start.

## The change

```python
     if config_entry.data.get(CONF_MAC) or config_entry.data.get(CONF_SN):
         return True
-    ip_address = config_entry.data.get(CONF_IP_ADDRESS)
+    # Honor an IP override set via the options flow (e.g. after a DHCP change),
+    # mirroring async_setup_entry; the data IP may be stale.
+    ip_address = config_entry.options.get(CONF_IP_ADDRESS)
+    if ip_address is None:
+        ip_address = config_entry.data.get(CONF_IP_ADDRESS)
     device_id = config_entry.data.get(CONF_DEVICE_ID)
     if ip_address is None or device_id is None:
         return True
-    found_devices = await hass.async_add_executor_job(
-        lambda: discover(ip_address=ip_address),
-    )
+    try:
+        found_devices = await hass.async_add_executor_job(
+            lambda: discover(ip_address=ip_address),
+        )
+    except Exception:
+        # Best-effort migration: any discovery failure (socket error, malformed
+        # reply from a legacy device, parse error) must not break entry setup.
+        # Retry on the next start instead.
+        _LOGGER.debug(
+            "Discovery for device %s failed; mac/serial number migration"
+            " will be retried on next start",
+            device_id,
+            exc_info=True,
+        )
+        return False
     device = found_devices.get(int(device_id))
```

## Findings considered but intentionally not changed here

The review ranked five findings. The two above were fixed; the other three were judged out of scope for this PR:

3. **Blocking 5s discovery repeats on every boot for un-backfilled/offline devices** — inherent to the best-effort-retry design; a real improvement (cache last-attempt, cap retries, or move off the startup path) is a deeper redesign worth its own change. *Skipped.*
4. **A `None` mac/sn can be written and the migration still marked complete** — verified no downstream harm: `midea_entity` guards on `if self._device.mac:`, so a `None` is inert. *Skipped.*
5. **`async_migrate_entry` returns `True` while still at 2.1 on a discovery miss** — deliberate: the device must still load, and staying at 2.1 is exactly what triggers the retry on the next start. *Skipped (correct as-is).*

## Verification

All four CI gates run locally against the exact pinned tool versions (ruff `v0.15.22`):

- `ruff check` → **All checks passed!**
- `ruff format --check` → **1 file already formatted**
- `pylint` → **10.00/10**
- `mypy` (`scripts/mypy.sh`, target Python 3.12) → **Success: no issues found in 19 source files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
