### PR TITLE
fix(ac): fan modes collapse to only "full" on stepless/inverter ACs

### DIFF
--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -511,6 +511,8 @@ class MideaACClimate(MideaClimate):
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return list(self._fan_speeds.keys())
+        if caps.get("fan_custom"):
+            return list(self._fan_speeds.keys())
         cap_by_fan = {
             FAN_SILENT: "fan_silent",
             FAN_LOW: "fan_low",

--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -504,13 +504,21 @@ class MideaACClimate(MideaClimate):
 
     @property
     def fan_modes(self) -> list[str] | None:
-        """fan_modes restricted to the speeds the device reports (B5).
+        """fan_modes: B5 capabilities > default full set.
 
-        Falls back to the full set when no capability is reported.
+        Read dynamically so capabilities decoded after the first refresh are
+        reflected (they are not yet available when the entity is created).
+
+        The B5 ``b5_wind_speed`` byte is a single capability profile (1-7), not
+        a bitmask: value 1 (``fan_custom``) means the fan is stepless/inverter
+        and accepts every speed, so all discrete modes are valid. Mapping
+        ``fan_custom`` to ``full`` alone collapsed the list to ``["full"]`` on
+        such units (issue #904); short-circuit to the full set instead.
         """
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return list(self._fan_speeds.keys())
+        # stepless/inverter fan: expose every discrete speed, not just "full"
         if caps.get("fan_custom"):
             return list(self._fan_speeds.keys())
         cap_by_fan = {


### PR DESCRIPTION
# PR Description

## Reason & Detail

On AC units with a stepless (inverter) fan (like the Midea Portasplit), the fan mode dropdown only offered `full` (`silent`/`low`/`medium`/`high`/`auto` were missing, even though the hardware supports them).

midealocal's B5 capability parser reports a stepless fan as only fan_custom=True (all named fan_* flags False). The `fan_modes` property maps `FAN_FULL_SPEED` to `fan_custom`, so the list collapsed to `["full"]`.

midea-ac-py handles the same hardware correctly because it OR-s every named speed with fan_custom: https://github.com/mill1000/midea-msmart/blob/main/msmart/device/AC/command.py#L727-L731

Tested with my local HA instance and works as intended.