### PR TITLE
fix(light): recompute color modes so dimmable lights are not stuck on/off

### DIFF
--- a/custom_components/midea_ac_lan/light.py
+++ b/custom_components/midea_ac_lan/light.py
@@ -73,18 +73,32 @@ def _calc_supported_color_modes(device: Midea13Device) -> set[ColorMode]:
 class MideaLight(MideaEntity, LightEntity):
     """Midea Light Entries."""
 
-    _attr_color_mode: ColorMode | str | None = None
-    _attr_supported_color_modes: set[ColorMode] | set[str] | None = None
-    _attr_supported_features: LightEntityFeature = LightEntityFeature(0)
-
     _device: Midea13Device
 
-    def __init__(self, device: Midea13Device, entity_key: str) -> None:
-        """Midea Light entity init."""
-        super().__init__(device, entity_key)
-        self._attr_supported_features = _calc_supported_features(device)
-        self._attr_supported_color_modes = _calc_supported_color_modes(device)
-        self._attr_color_mode = self._calc_color_mode(self._attr_supported_color_modes)
+    # NOTE: supported_features / supported_color_modes / color_mode are computed
+    # as properties (not latched in __init__). The device starts its socket
+    # refresh on a background thread, so at construction time brightness,
+    # color_temperature and rgb_color are all still None. Latching these in
+    # __init__ would lock a dimmable/color-temp light to ONOFF forever, because
+    # update_state never recomputes them. Recomputing per access reflects the
+    # capabilities once the first status arrives.
+    @property
+    def supported_features(self) -> LightEntityFeature:
+        """Midea Light supported features."""
+        return _calc_supported_features(self._device)
+
+    @property
+    def supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+        """Midea Light supported color modes."""
+        return _calc_supported_color_modes(self._device)
+
+    @property
+    def color_mode(self) -> ColorMode | str | None:
+        """Midea Light current color mode."""
+        # Call the concrete helper (returns set[ColorMode]) rather than the
+        # supported_color_modes property, whose type is widened to
+        # set[ColorMode] | set[str] | None to match LightEntity's base override.
+        return self._calc_color_mode(_calc_supported_color_modes(self._device))
 
     def _calc_color_mode(self, supported: set[ColorMode]) -> ColorMode:
         """Midea Light calculate color mode.


### PR DESCRIPTION
## Problem

A dimmable / colour-temperature Midea light (device type `0x13`) shows up in Home Assistant as a plain **on/off** light — the brightness slider and colour-temperature control never appear, even after the device is fully online.

### Root cause

`MideaLight` latched its capability attributes **once in `__init__`**:

```python
def __init__(self, device, entity_key):
    super().__init__(device, entity_key)
    self._attr_supported_features = _calc_supported_features(device)
    self._attr_supported_color_modes = _calc_supported_color_modes(device)   # latched
    self._attr_color_mode = self._calc_color_mode(self._attr_supported_color_modes)  # latched
```

`_calc_supported_color_modes()` reads the device's live `brightness` / `color_temperature` / `rgb_color` attributes:

```python
if device.get_attribute(X13Attributes.color_temperature) is not None: supported.add(COLOR_TEMP)
if device.get_attribute(X13Attributes.rgb_color) is not None:         supported.add(HS)
if not supported and device.get_attribute(X13Attributes.brightness) is not None: supported = {BRIGHTNESS}
if not supported: supported = {ColorMode.ONOFF}
```

But `MideaDevice` is a `threading.Thread`; `device.open()` starts the connection and the first status refresh **on a background thread and returns immediately**. The entity is constructed right after, in the same setup coroutine, before any status frame arrives — so at construction time `brightness`, `color_temperature` and `rgb_color` are **all `None`** (their `x13` defaults). The result:

- `supported_color_modes` latches to `{ColorMode.ONOFF}`
- `color_mode` latches to `ColorMode.ONOFF`

`update_state()` only calls `schedule_update_if_running()`; it **never recomputes** these, so the light stays locked to on/off for the entity's whole lifetime. It re-latches to ONOFF on every HA restart.

### Before

```
light.living_room_lamp
  supported_color_modes: [onoff]      # brightness/color_temp never exposed
  color_mode: onoff
```

## Fix

Convert `supported_features`, `supported_color_modes` and `color_mode` from latched `__init__` attributes into `@property` methods, so they are recomputed on each access — once the first status has arrived they reflect the real capabilities. This mirrors how `climate.py` already exposes its dynamic capability lists (`hvac_modes`, `fan_modes`, …) as properties.

### After

```
light.living_room_lamp
  supported_color_modes: [color_temp]  # or [brightness]
  color_mode: color_temp
  # brightness slider + color-temp control now render
```

## Scope

- Single file: `custom_components/midea_ac_lan/light.py`
- No registry / translation changes.
- `ruff check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)