### PR TITLE
fix(fan): stop capitalizing preset mode so CE "ECO mode" works

### DIFF
--- a/custom_components/midea_ac_lan/fan.py
+++ b/custom_components/midea_ac_lan/fan.py
@@ -122,7 +122,13 @@ class MideaFan(MideaEntity, FanEntity):
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Midea Fan set preset mode."""
-        self._device.set_attribute(attr="mode", value=preset_mode.capitalize())
+        # Pass the preset value through unchanged. `preset_modes` already
+        # returns the device's own strings and HA only ever hands one of them
+        # back, so the value is guaranteed valid. Do NOT `.capitalize()` it:
+        # that corrupts multi-word / mixed-case names such as the CE fan's
+        # "ECO mode" -> "Eco mode", which the device matches case-sensitively
+        # and silently drops, making the ECO preset unselectable.
+        self._device.set_attribute(attr="mode", value=preset_mode)
 
     @property
     def percentage(self) -> int | None:


### PR DESCRIPTION
## Problem

On a **CE** fan, selecting the **ECO mode** preset does nothing — the fan silently reverts to Normal. Sleep mode and Normal work fine.

### Root cause

The base `MideaFan.set_preset_mode` capitalizes the value before sending it:

```python
def set_preset_mode(self, preset_mode: str) -> None:
    self._device.set_attribute(attr="mode", value=preset_mode.capitalize())
```

`MideaCEFan` does **not** override this, so CE presets flow through it. The CE device (`midealocal`) publishes and matches these exact, case-sensitive strings:

```python
_modes = ["Normal", "Sleep mode", "ECO mode"]
...
if value == "Sleep mode":   message.sleep_mode = True
elif value == "ECO mode":   message.eco_mode = True
# anything else -> both flags stay False (silent clear)
```

`"ECO mode".capitalize()` → `"Eco mode"`, which matches **neither** branch, so both flags are left `False` and the command clears the mode instead of enabling ECO.

`"ECO mode"` is the only preset with a non-initial capital, so it's the only one `.capitalize()` mangles:
- `"Sleep mode".capitalize()` → `"Sleep mode"` ✅ (no-op)
- `"Normal".capitalize()` → `"Normal"` ✅
- FA / B6 presets are all single Title-case words → `.capitalize()` is a no-op → unaffected

The getter (`preset_mode`) returns the device's exact `"ECO mode"`, so only the **write** path was broken.

### Before

```
fan.set_preset_mode(entity_id="fan.ce_unit", preset_mode="ECO mode")
# sends "Eco mode" -> device clears both flags -> mode falls back to Normal
```

## Fix

Pass the preset value through unchanged. `preset_modes` already exposes the device's own exact strings and HA only ever passes one of them back, so the value is guaranteed valid — no normalization is needed. `MideaACFreshAirFan.set_preset_mode` already does exactly this.

### After

```
fan.set_preset_mode(entity_id="fan.ce_unit", preset_mode="ECO mode")
# sends "ECO mode" -> device sets eco_mode = True ✅
```

## Scope

- Single file: `custom_components/midea_ac_lan/fan.py` (one line + explanatory comment)
- Affects the base method shared by FA / B6 / CE; verified capitalize-stable for FA/B6, so behavior is unchanged for them and fixed for CE.
- `ruff check` passes.

### Note (out of scope)

The CE device separately reports `"None"` (not `"Normal"`) when neither flag is set, so the `"Normal"` label doesn't round-trip either. That's a library-side label mismatch (`midea-local`), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)