### PR TITLE
fix(da): correct wash_level label duplicated as "Rinse count"

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -2247,7 +2247,7 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
             DAAttributes.wash_level: {
                 "type": Platform.SENSOR,
                 "translation_key": "wash_level",
-                "name": "Rinse count",
+                "name": "Wash level",
                 "icon": "mdi:hydraulic-oil-level",
             },
             DAAttributes.wash_strength: {

--- a/custom_components/midea_ac_lan/translations/de.json
+++ b/custom_components/midea_ac_lan/translations/de.json
@@ -688,7 +688,7 @@
         "name": "TVOC"
       },
       "wash_level": {
-        "name": "rinse count"
+        "name": "Waschstufe"
       },
       "wash_strength": {
         "name": "wash strength"

--- a/custom_components/midea_ac_lan/translations/en.json
+++ b/custom_components/midea_ac_lan/translations/en.json
@@ -688,7 +688,7 @@
         "name": "TVOC"
       },
       "wash_level": {
-        "name": "Rinse count"
+        "name": "Wash level"
       },
       "wash_strength": {
         "name": "Wash strength"

--- a/custom_components/midea_ac_lan/translations/es.json
+++ b/custom_components/midea_ac_lan/translations/es.json
@@ -688,7 +688,7 @@
         "name": "COVT"
       },
       "wash_level": {
-        "name": "Recuento de aclarados"
+        "name": "Nivel de lavado"
       },
       "wash_strength": {
         "name": "Potencia de lavado"

--- a/custom_components/midea_ac_lan/translations/fr.json
+++ b/custom_components/midea_ac_lan/translations/fr.json
@@ -688,7 +688,7 @@
         "name": "TVOC"
       },
       "wash_level": {
-        "name": "rinse count"
+        "name": "Niveau de lavage"
       },
       "wash_strength": {
         "name": "wash strength"

--- a/custom_components/midea_ac_lan/translations/hu.json
+++ b/custom_components/midea_ac_lan/translations/hu.json
@@ -688,7 +688,7 @@
         "name": "TVOC"
       },
       "wash_level": {
-        "name": "rinse count"
+        "name": "Mosási szint"
       },
       "wash_strength": {
         "name": "wash strength"

--- a/custom_components/midea_ac_lan/translations/it.json
+++ b/custom_components/midea_ac_lan/translations/it.json
@@ -688,7 +688,7 @@
         "name": "TVOC"
       },
       "wash_level": {
-        "name": "Numero Risciacqui"
+        "name": "Livello di lavaggio"
       },
       "wash_strength": {
         "name": "Intensità Lavaggio"

--- a/custom_components/midea_ac_lan/translations/ru.json
+++ b/custom_components/midea_ac_lan/translations/ru.json
@@ -688,7 +688,7 @@
         "name": "TVOC"
       },
       "wash_level": {
-        "name": "Количество полосканий"
+        "name": "Уровень стирки"
       },
       "wash_strength": {
         "name": "Wash strength"

--- a/custom_components/midea_ac_lan/translations/sk.json
+++ b/custom_components/midea_ac_lan/translations/sk.json
@@ -688,7 +688,7 @@
         "name": "TVOC"
       },
       "wash_level": {
-        "name": "rinse count"
+        "name": "Úroveň prania"
       },
       "wash_strength": {
         "name": "wash strength"


### PR DESCRIPTION
## Problem

A 0xDA washing machine exposes **two sensors both named "Rinse count"**, and **no "Wash level"** sensor at all.

### Root cause

In the device registry, the `wash_level` entry carried a copy-pasted `name` from its sibling `rinse_count` (two entries above it):

```python
DAAttributes.rinse_count: {
    "type": Platform.SENSOR,
    "translation_key": "rinse_count",
    "name": "Rinse count",
    "icon": "mdi:water-sync",
},
...
DAAttributes.wash_level: {
    "type": Platform.SENSOR,
    "translation_key": "wash_level",
    "name": "Rinse count",        # <-- wrong, should be "Wash level"
    "icon": "mdi:hydraulic-oil-level",
},
```

The same wrong label was mirrored in the translation files, so it actually renders in the UI. Every locale except `zh-Hans` had `wash_level.name` set to a "rinse count" variant (either the untranslated English placeholder or a translated "rinse count").

### Before (English UI)

```
sensor.washer_rinse_count   -> "Rinse count"
sensor.washer_wash_level    -> "Rinse count"   # duplicate, misleading
```

## Fix

- `midea_devices.py`: set `wash_level`'s `name` to `"Wash level"`.
- Correct the `wash_level` string in each locale: `en, de, es, fr, hu, it, ru, sk` (`zh-Hans` was already correct: 洗涤档位).

### After

```
sensor.washer_rinse_count   -> "Rinse count"
sensor.washer_wash_level    -> "Wash level"    # correct
```

## Scope

- 1 registry line + 1 line per locale (9 files, 1 line each).
- All translation JSON validated (`json.load`).
- No key added/removed — parity with `en.json` is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)