### PR TITLE
fix(entity): route sensor/select/button updates through shutdown guard

### DIFF
--- a/custom_components/midea_ac_lan/button.py
+++ b/custom_components/midea_ac_lan/button.py
@@ -98,9 +98,5 @@ class MideaButton(MideaEntity, ButtonEntity):
     def update_state(self, status: Any) -> None:  # ruff:ignore[any-type]
         """Update entity state."""
         super().update_state(status)
-        if (
-            self.hass
-            and not self.hass.is_stopping
-            and ("mode" in status or self._power_attribute in status)
-        ):
-            self.schedule_update_ha_state()
+        if self.hass and ("mode" in status or self._power_attribute in status):
+            self.schedule_update_if_running()

--- a/custom_components/midea_ac_lan/select.py
+++ b/custom_components/midea_ac_lan/select.py
@@ -125,10 +125,9 @@ class MideaSelect(MideaEntity, SelectEntity):
         if (
             power_attribute
             and self.hass
-            and not self.hass.is_stopping
             and (self._attribute_key in status or power_attribute in status)
         ):
-            self.schedule_update_ha_state()
+            self.schedule_update_if_running()
 
     @staticmethod
     def _get_dict_key_by_value(source: dict[int, str], value: str) -> int | None:

--- a/custom_components/midea_ac_lan/sensor.py
+++ b/custom_components/midea_ac_lan/sensor.py
@@ -185,9 +185,7 @@ class MideaEstimatedUsageSensor(MideaSensor, RestoreEntity):
 
         self._last_progress = current_progress
         super().update_state(status)
-        if (
-            self.hass
-            and not self.hass.is_stopping
-            and ("progress" in status or "status" in status or "mode" in status)
+        if self.hass and (
+            "progress" in status or "status" in status or "mode" in status
         ):
-            self.schedule_update_ha_state()
+            self.schedule_update_if_running()


### PR DESCRIPTION
## Problem

During Home Assistant shutdown, the Midea `midealocal` device delivers a final status update from its **background socket thread**. For the estimated-usage sensor, the E1 mode select, and the dishwasher start button, that could raise:

```
RuntimeError: Event loop is closed
```

thrown from the device thread — the exact crash that `MideaEntity.schedule_update_if_running()` was created to prevent (issues #798 / #809).

### Root cause

Those three overrides pushed state directly:

```python
if self.hass and not self.hass.is_stopping and (... in status):
    self.schedule_update_ha_state()
```

The `is_stopping` flag alone is not enough — there is a race between checking it and the actual schedule call. `MideaEntity.schedule_update_if_running()` centralizes the full guard:

```python
if self.hass.is_stopping: return
if self.hass.loop.is_closed(): return          # <- also checks the closed loop
try:
    self.schedule_update_ha_state()
except RuntimeError:
    if not self.hass.loop.is_closed(): raise    # <- swallows the shutdown race
```

Every other platform (climate/fan/light/water_heater/humidifier) and the base `update_state` already use this helper. These three were the only paths still calling `schedule_update_ha_state()` directly. It matters specifically for them because their base `update_state` early-returns (the synthetic keys `estimated_energy_consumption` / `mode_select` / `start` are never in the device `status` dict), so the override is the **only** state-push path.

## Fix

Replace `self.schedule_update_ha_state()` with `self.schedule_update_if_running()` in `sensor.py`, `select.py`, `button.py`, and drop the now-redundant `is_stopping` check (the helper re-checks it). The existing attribute-filter conditions are preserved.

- Normal operation: identical behavior.
- Shutdown: the closed-loop `RuntimeError` is guarded/swallowed instead of surfacing.

## Scope

- 3 files, small diffs.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)