### PR TITLE
fix(config_flow): stop mutating options list while iterating it

### DIFF
--- a/custom_components/midea_ac_lan/config_flow.py
+++ b/custom_components/midea_ac_lan/config_flow.py
@@ -917,14 +917,12 @@ class MideaLanOptionsFlowHandler(OptionsFlow):
         self._device_type = config_entry.data.get(CONF_TYPE)
         if self._device_type is None:
             self._device_type = 0xAC
-        if CONF_SENSORS in self._config_entry.options:
-            for key in self._config_entry.options[CONF_SENSORS]:
-                if key not in MIDEA_DEVICES[self._device_type]["entities"]:
-                    self._config_entry.options[CONF_SENSORS].remove(key)
-        if CONF_SWITCHES in self._config_entry.options:
-            for key in self._config_entry.options[CONF_SWITCHES]:
-                if key not in MIDEA_DEVICES[self._device_type]["entities"]:
-                    self._config_entry.options[CONF_SWITCHES].remove(key)
+        # Stale keys (attributes no longer in MIDEA_DEVICES) are filtered out
+        # downstream in async_step_init, where the multi-select defaults are
+        # computed as `set(sensors) & set(options)` / `set(switches) & ...` —
+        # both `sensors` and `switches` are built only from valid entities. No
+        # pruning is needed here; doing it in place mutated the list while
+        # iterating (skipping elements) and mutated HA-owned entry state.
 
     async def async_step_init(
         self,


### PR DESCRIPTION
## Problem

`MideaLanOptionsFlowHandler.__init__` pruned stale entity keys like this:

```python
if CONF_SENSORS in self._config_entry.options:
    for key in self._config_entry.options[CONF_SENSORS]:
        if key not in MIDEA_DEVICES[self._device_type]["entities"]:
            self._config_entry.options[CONF_SENSORS].remove(key)
```

Two bugs:

1. **Mutation during iteration** — calling `.remove()` on the list being iterated makes the iterator skip the element *after* each removed one. Two consecutive stale keys → the second survives.
2. **Mutating HA-owned state** — it writes to `config_entry.options` in place instead of going through `hass.config_entries.async_update_entry(...)`. Config-entry option lists shouldn't be mutated directly.

### Failure example

```python
options[CONF_SENSORS] == ["stale_a", "stale_b", "valid_c"]
# iterate idx 0 -> remove "stale_a"; list now ["stale_b","valid_c"], iterator jumps to idx 1
# iterate idx 1 -> "valid_c" (kept). "stale_b" was skipped and remains.
# result: ["stale_b", "valid_c"]   # stale_b leaked into the options schema
```

## Fix

Delete the pruning loop. It's **redundant** — `async_step_init` already filters stale keys when building the form defaults:

```python
extra_sensors  = list(set(sensors.keys())  & set(options.get(CONF_SENSORS, [])))
extra_switches = list(set(switches.keys()) & set(options.get(CONF_SWITCHES, [])))
```

`sensors` / `switches` are populated only from valid `MIDEA_DEVICES[...]["entities"]`, so any attribute no longer in the registry is already excluded from the multi-select (both its options and its default). Removing the buggy loop changes nothing for valid keys and correctly drops all stale ones.

## Scope

- Single file: `custom_components/midea_ac_lan/config_flow.py` (removes 8 lines, adds a comment).
- `ruff check` clean; `MIDEA_DEVICES` import still used elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)