### PR TITLE
fix(registry): correct invalid and non-standard entity icons

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -1022,7 +1022,7 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
                 "type": Platform.BINARY_SENSOR,
                 "translation_key": "top_compartment_cooling",
                 "name": "Top Compartment Cooling",
-                "icon": "snowflake-variant",
+                "icon": "mdi:snowflake-variant",
                 "device_class": BinarySensorDeviceClass.RUNNING,
             },
             B3Attributes.middle_compartment_door: {
@@ -1043,7 +1043,7 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
                 "type": Platform.BINARY_SENSOR,
                 "translation_key": "middle_compartment_cooling",
                 "name": "Middle Compartment Cooling",
-                "icon": "snowflake-variant",
+                "icon": "mdi:snowflake-variant",
                 "device_class": BinarySensorDeviceClass.RUNNING,
             },
             B3Attributes.bottom_compartment_door: {
@@ -1064,7 +1064,7 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
                 "type": Platform.BINARY_SENSOR,
                 "translation_key": "bottom_compartment_cooling",
                 "name": "Bottom Compartment Cooling",
-                "icon": "snowflake-variant",
+                "icon": "mdi:snowflake-variant",
                 "device_class": BinarySensorDeviceClass.RUNNING,
             },
             B3Attributes.top_compartment_status: {
@@ -1750,7 +1750,7 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
         "entities": {
             "climate": {
                 "type": Platform.CLIMATE,
-                "icon": "hass:air-conditioner",
+                "icon": "mdi:air-conditioner",
                 "default": True,
             },
             CCAttributes.aux_heating: {
@@ -2161,7 +2161,7 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
         "entities": {
             "climate": {
                 "type": Platform.CLIMATE,
-                "icon": "hass:air-conditioner",
+                "icon": "mdi:air-conditioner",
                 "default": True,
             },
             CFAttributes.aux_heating: {
@@ -2922,7 +2922,6 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
                 "type": Platform.BINARY_SENSOR,
                 "translation_key": "finished",
                 "name": "Finished",
-                "icon": "",
             },
             E8Attributes.water_shortage: {
                 "type": Platform.BINARY_SENSOR,


### PR DESCRIPTION
## Problem

Three icon issues in the device registry (`midea_devices.py`):

1. **0xB3 compartment-cooling binary sensors** — `top`/`middle`/`bottom_compartment_cooling` set `"icon": "snowflake-variant"`, **missing the `mdi:` prefix**. Without the namespace it's not a valid MDI icon and won't render (contrast `mdi:snowflake-alert` used elsewhere in the same device).
2. **0xE8 `finished` binary sensor** — `"icon": ""`. The base `icon` property returns the raw config value with no empty-string guard:
   ```python
   @property
   def icon(self) -> str:
       return cast("str", self._config.get("icon"))
   ```
   An empty string forces "no icon" and suppresses the default icon HA would otherwise derive from the device class / state.
3. **Two `climate` entries** — use the deprecated `hass:` icon prefix (`hass:air-conditioner`). Still resolves, but `mdi:` is the current standard.

## Fix

| Location | Before | After |
|---|---|---|
| 0xB3 ×3 cooling sensors | `"snowflake-variant"` | `"mdi:snowflake-variant"` |
| 0xE8 `finished` | `"icon": ""` | *(key removed → HA default)* |
| 2× `climate` | `"hass:air-conditioner"` | `"mdi:air-conditioner"` |

## Verification

- `grep` confirms no remaining icons without the `mdi:` prefix and no empty icon strings.
- `ruff check` passes.

## Scope

- Single file, 6 lines. Pure metadata; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)