### PR TITLE
fix(climate): bounds-check device mode before indexing hvac list

### DIFF
--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -146,7 +146,10 @@ class MideaClimate(MideaEntity, ClimateEntity):
         """Midea Climate hvac mode."""
         if self._device.get_attribute("power"):
             mode = cast("int", self._device.get_attribute("mode"))
-            return self.hvac_modes[mode]
+            # Guard against an out-of-range/undefined device mode so a malformed
+            # frame cannot raise IndexError on every state render.
+            if 0 <= mode < len(self.hvac_modes):
+                return self.hvac_modes[mode]
         return HVACMode.OFF
 
     @property
@@ -450,7 +453,10 @@ class MideaACClimate(MideaClimate):
         """Midea AC Climate hvac mode (device mode int -> fixed map)."""
         if self._device.get_attribute("power"):
             mode = cast("int", self._device.get_attribute("mode"))
-            return self._mode_index[mode]
+            # The AC `mode` field is a 3-bit value (0-7) but `_mode_index` only
+            # maps 0-5; guard so an out-of-spec 6/7 cannot raise IndexError.
+            if 0 <= mode < len(self._mode_index):
+                return self._mode_index[mode]
         return HVACMode.OFF
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -814,7 +820,11 @@ class MideaC3Climate(MideaClimate):
     def hvac_mode(self) -> HVACMode:
         """Midea C3 Climate hvac mode."""
         mode = self._device.get_attribute(C3Attributes.mode)
-        if self._device.get_attribute(self._power_attr) and isinstance(mode, int):
+        if (
+            self._device.get_attribute(self._power_attr)
+            and isinstance(mode, int)
+            and 0 <= mode < len(self.hvac_modes)
+        ):
             return self.hvac_modes[mode]
         return HVACMode.OFF
 


### PR DESCRIPTION
## Problem

Three climate classes index a mode list directly with the raw device `mode`:

```python
# MideaClimate (base), MideaC3Climate
return self.hvac_modes[mode]
# MideaACClimate
return self._mode_index[mode]        # _mode_index has 6 entries (0-5)
```

The AC `mode` field is decoded from 3 bits and stored **unclamped**:

```python
# midealocal ac/message.py
self.mode = (body[2] & 0xE0) >> 5    # 0xE0 = 3-bit field -> range 0-7
# ac/__init__.py stores it verbatim, no clamping
```

Normal firmware only emits modes 1-5, so this is safe in practice — but a malformed frame or out-of-spec firmware reporting mode **6 or 7** indexes past the end of the list → `IndexError`. Since `hvac_mode` is re-evaluated on **every** state render, a persistently bad value errors the climate entity repeatedly.

Severity: low (requires out-of-spec/malformed data), but the read path is genuinely unbounded, so a defensive guard is warranted.

## Fix

Add an explicit range check to each of the three `hvac_mode` read properties and fall back to `HVACMode.OFF` when the mode is out of range:

```python
if 0 <= mode < len(self.hvac_modes):     # or len(self._mode_index)
    return self.hvac_modes[mode]
return HVACMode.OFF
```

- Normal operation (modes 1-5): unchanged.
- Out-of-range mode: returns `OFF` instead of raising.
- The write paths (`set_hvac_mode` / `set_temperature`) already used `.index()` (value→index) and were never affected.
- The FB climate `hvac_mode` (power→HEAT/OFF, no indexing) needs no change.

## Scope

- Single file: `custom_components/midea_ac_lan/climate.py`, three small guards.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)