### PR TITLE
fix(diagnostics): redact device mac address and serial number

### DIFF
--- a/custom_components/midea_ac_lan/diagnostics.py
+++ b/custom_components/midea_ac_lan/diagnostics.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
-from .const import CONF_KEY
+from .const import CONF_KEY, CONF_MAC, CONF_SN
 
-TO_REDACT = {CONF_TOKEN, CONF_KEY}
+TO_REDACT = {CONF_TOKEN, CONF_KEY, CONF_MAC, CONF_SN}
 
 
 async def async_get_config_entry_diagnostics(


### PR DESCRIPTION
## Problem

`diagnostics.py` only redacted the token and key:

```python
TO_REDACT = {CONF_TOKEN, CONF_KEY}
```

So a downloaded diagnostics file still contained the device **MAC address** (`mac`) and **serial number** (`sn`) in clear text. Users routinely attach diagnostics to GitHub issues and forum posts; MAC/SN are device-identifying values that should be scrubbed by default.

## Fix

```python
TO_REDACT = {CONF_TOKEN, CONF_KEY, CONF_MAC, CONF_SN}
```

`async_redact_data` recurses into the nested `entry.as_dict()`, so both keys are redacted wherever they appear.

### Note

Cloud account / password are **not** affected — they're stored only in `hass.data[DOMAIN]["login_data"]` (in-memory), never in the config entry, so they don't appear in diagnostics at all.

## Scope

- Single file: `custom_components/midea_ac_lan/diagnostics.py` (import + set).
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)