### PR TITLE
chore: remove stale requirements.txt leftover from uv migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-midea-local==6.8.0


### PR DESCRIPTION
## Problem

`requirements.txt` (repo root) contains a single, **stale** pin:

```
midea-local==6.8.0
```

The authoritative pins are all `6.11.1`:
- `custom_components/midea_ac_lan/manifest.json` → `"midea-local==6.11.1"`
- `pyproject.toml` / `uv.lock`

Nothing in CI, `scripts/`, `.github/`, or `pyproject.toml` references `requirements.txt` — it was orphaned by the migration to uv (PR #871). But `.github/dependabot.yml` runs the **`pip` ecosystem on `/`**, so this file is still scanned and presents a conflicting, out-of-date dependency view (and would generate misleading bump PRs).

## Fix

Delete `requirements.txt`. `pyproject.toml` + `uv.lock` are the single source of truth for dependencies, and `manifest.json` is what Home Assistant/HACS actually install from. Dependabot's pip ecosystem falls back to `pyproject.toml`.

## Scope

- Deletes one orphaned file. No code or CI references it.

## Alternative

If you'd prefer to keep the file for some external tooling, I can bump it to `6.11.1` instead — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)