### PR TITLE
fix(hacs): raise advertised minimum Home Assistant to 2024.4.1

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Midea AC LAN",
-  "homeassistant": "2023.8",
+  "homeassistant": "2024.4.1",
   "zip_release": true,
   "filename": "midea_ac_lan.zip"
 }


### PR DESCRIPTION
## Problem

`hacs.json` advertises:

```json
"homeassistant": "2023.8"
```

But the integration's real minimum is **2024.4.1**:
- Documented in `AGENTS.md` ("Minimum Home Assistant: **2024.4.1**").
- Reflected in the dev/lock pins.
- The code branches on newer HA APIs via `(MAJOR_VERSION, MINOR_VERSION)` guards.

Understating the minimum in `hacs.json` lets HACS install/offer the integration on unsupported HA versions, where setup can fail in non-obvious ways.

## Fix

```json
"homeassistant": "2024.4.1"
```

Aligns the HACS-advertised floor with the actually-supported version.

## Scope

- Single file: `hacs.json` (one line). JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)