### PR TITLE
fix(entity): avoid doubled device name in the fallback entity name

### DIFF
--- a/custom_components/midea_ac_lan/midea_entity.py
+++ b/custom_components/midea_ac_lan/midea_entity.py
@@ -79,13 +79,15 @@ class MideaEntity(Entity):
         # Example: device_class = temperature -> "Temperature".
         elif "device_class" in self._config:
             self._attr_name = None  # Let HA generate from device_class
-        # Step 4: Nothing available,
+        # Step 4: Nothing available (no translation_key, no name, no
+        # device_class). With has_entity_name=True HA already prepends the
+        # device name, so the entity's own name must be None — the entity then
+        # represents the device's main feature and shows just the device name.
+        # (The previous fallback embedded the device name itself, yielding a
+        # doubled "DeviceName DeviceName", or "DeviceName None" when a null
+        # "name" key was present.)
         else:
-            self._attr_name = (
-                f"{self._device_name} {self._config.get('name')}"
-                if "name" in self._config
-                else f"{self._device_name}"
-            )
+            self._attr_name = None
 
     @property
     def device(self) -> MideaDevice:


### PR DESCRIPTION
## Problem

`MideaEntity.__init__` resolves the entity name in four steps. Step 4 (the final fallback, reached when there is **no** `translation_key`, **no** explicit non-null `name`, and **no** `device_class`) did:

```python
self._attr_name = (
    f"{self._device_name} {self._config.get('name')}"
    if "name" in self._config
    else f"{self._device_name}"
)
```

But `_attr_has_entity_name = True` is set just above, and with that flag **Home Assistant already prepends the device name** to the entity's own name. So this fallback double-counts it:

- no `name` key → entity name = `"DeviceName"` → UI shows **"DeviceName DeviceName"**
- null `name` key present → entity name = `"DeviceName None"` → UI shows **"DeviceName DeviceName None"**

(The inner `if "name" in self._config` is only reachable when `name` is explicitly `None`, since a non-None name was already handled in Step 2.)

## Fix

```python
else:
    self._attr_name = None
```

With `has_entity_name = True`, `_attr_name = None` is the documented way to say "this entity represents the device's main feature" — HA then displays just the device name, with no duplication.

### Note

This branch requires a config lacking **all** of `translation_key` / `name` / `device_class`. Nearly every entry in `MIDEA_DEVICES` sets `translation_key`, so it's rarely (if ever) hit today — this makes the fallback correct rather than fixing an active regression.

## Scope

- Single file: `custom_components/midea_ac_lan/midea_entity.py`.
- `_device_name` is still used by `device_info`; nothing orphaned. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)