### PR TITLE
refactor(number): make min/max/step bound resolver robust

### DIFF
--- a/custom_components/midea_ac_lan/number.py
+++ b/custom_components/midea_ac_lan/number.py
@@ -44,53 +44,41 @@ class MideaNumber(MideaEntity, NumberEntity):
         self._min_value = self._config.get("min")
         self._step_value = self._config.get("step")
 
+    def _resolve_bound(self, bound: Any) -> float:  # ruff:ignore[any-type]
+        """Resolve a min/max/step config value to a concrete number.
+
+        A numeric literal is used as-is. Otherwise the value is treated as an
+        attribute name: prefer the device attribute of that name, falling back
+        to a same-named device property populated by ``set_customize``.
+
+        Returns
+        -------
+        The resolved bound as a float.
+
+        """
+        if isinstance(bound, (int, float)):
+            return cast("float", bound)
+        # `bound` is an attribute name. Use `is not None` (not truthiness) so a
+        # legitimate 0 is not treated as "missing", and read the attribute once.
+        value = self._device.get_attribute(attr=bound)
+        if value is None:
+            value = getattr(self._device, bound)
+        return cast("float", value)
+
     @property
     def native_min_value(self) -> float:
         """Minimum value allowed."""
-        return cast(
-            "float",
-            (
-                self._min_value
-                if isinstance(self._min_value, int)
-                else (
-                    self._device.get_attribute(attr=self._min_value)
-                    if self._device.get_attribute(attr=self._min_value)
-                    else getattr(self._device, self._min_value)
-                )
-            ),
-        )
+        return self._resolve_bound(self._min_value)
 
     @property
     def native_max_value(self) -> float:
         """Maximum value allowed."""
-        return cast(
-            "float",
-            (
-                self._max_value
-                if isinstance(self._max_value, int)
-                else (
-                    self._device.get_attribute(attr=self._max_value)
-                    if self._device.get_attribute(attr=self._max_value)
-                    else getattr(self._device, self._max_value)
-                )
-            ),
-        )
+        return self._resolve_bound(self._max_value)
 
     @property
     def native_step(self) -> float:
         """Step value between allowed values."""
-        return cast(
-            "float",
-            (
-                self._step_value
-                if isinstance(self._step_value, int)
-                else (
-                    self._device.get_attribute(attr=self._step_value)
-                    if self._device.get_attribute(attr=self._step_value)
-                    else getattr(self._device, self._step_value)
-                )
-            ),
-        )
+        return self._resolve_bound(self._step_value)
 
     @property
     def native_value(self) -> float:


### PR DESCRIPTION
## Problem

`native_min_value`, `native_max_value` and `native_step` each repeated the same bound-resolution expression, which has two latent bugs (both currently masked by the existing configs):

```python
self._min_value
if isinstance(self._min_value, int)
else (
    self._device.get_attribute(attr=self._min_value)
    if self._device.get_attribute(attr=self._min_value)      # truthiness + double call
    else getattr(self._device, self._min_value)
)
```

1. **Truthiness treats `0` as missing.** `if get_attribute(x)` is falsy for a legitimate `0`, so a real bound of `0` falls through to `getattr`. It also calls `get_attribute` twice.
2. **`isinstance(x, int)` misclassifies floats.** A float bound (e.g. a `0.5` step) isn't an `int`, so it would be treated as an *attribute name* → `get_attribute(0.5)` / `getattr(device, 0.5)` → `TypeError: attribute name must be string`.

These don't trigger today only because all current bounds are `int` literals or string attribute-names that aren't `DeviceAttributes` members (so `get_attribute` returns `None` and the `getattr` property is used). But the resolver is fragile for any future `"max": "<attr>"` whose value can be `0`, or any float bound.

## Fix

Extract one `_resolve_bound(bound)` helper used by all three properties:

```python
def _resolve_bound(self, bound):
    if isinstance(bound, (int, float)):
        return cast("float", bound)
    value = self._device.get_attribute(attr=bound)   # read once
    if value is None:                                 # explicit sentinel, not truthiness
        value = getattr(self._device, bound)
    return cast("float", value)
```

- `int`/`float` literals → used as-is (identical to today for the existing int bounds).
- Attribute-name strings → `get_attribute` once, `is not None` check, then property fallback (same resolution order as before).
- A real `0` attribute value is now honored; float bounds no longer break.

Also de-duplicates ~45 lines into one helper.

## Scope

- Single file: `custom_components/midea_ac_lan/number.py`.
- `ruff check` + `ruff format` clean. No behavior change for current `MIDEA_DEVICES` configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)