### PR TITLE
feat(water_heater): advertise ON_OFF for E3/E6/C3

### DIFF
--- a/custom_components/midea_ac_lan/water_heater.py
+++ b/custom_components/midea_ac_lan/water_heater.py
@@ -243,6 +243,16 @@ class MideaE3WaterHeater(MideaWaterHeater):
         super().__init__(device, entity_key)
 
     @property
+    def supported_features(self) -> WaterHeaterEntityFeature:
+        """Midea E3 Water Heater supported features."""
+        # E3 implements turn_on/turn_off and reports on/off state, so advertise
+        # ON_OFF to self-document that support (matches E2).
+        return (
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE
+            | WaterHeaterEntityFeature.ON_OFF
+        )
+
+    @property
     def min_temp(self) -> float:
         """Midea E3 Water Heater min temperature."""
         return E3_TEMPERATURE_MIN
@@ -275,6 +285,16 @@ class MideaC3WaterHeater(MideaWaterHeater):
     def __init__(self, device: MideaC3Device, entity_key: str) -> None:
         """Midea C3 Water Heater entity init."""
         super().__init__(device, entity_key)
+
+    @property
+    def supported_features(self) -> WaterHeaterEntityFeature:
+        """Midea C3 Water Heater supported features."""
+        # C3 implements turn_on/turn_off (dhw_power) and reports on/off state,
+        # so advertise ON_OFF to self-document that support (matches E2).
+        return (
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE
+            | WaterHeaterEntityFeature.ON_OFF
+        )
 
     @property
     def current_operation(self) -> str:
@@ -355,6 +375,16 @@ class MideaE6WaterHeater(MideaWaterHeater):
         self._target_temperature_attr = MideaE6WaterHeater._target_temperatures[
             self._use
         ]
+
+    @property
+    def supported_features(self) -> WaterHeaterEntityFeature:
+        """Midea E6 Water Heater supported features."""
+        # E6 implements turn_on/turn_off and reports on/off state, so advertise
+        # ON_OFF to self-document that support (matches E2).
+        return (
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE
+            | WaterHeaterEntityFeature.ON_OFF
+        )
 
     @property
     def current_operation(self) -> str:


### PR DESCRIPTION
## Background

The water-heater subclasses declare their capabilities via `supported_features`:

| Subclass | `supported_features` | turn_on/off | on/off state |
|---|---|---|---|
| base `MideaWaterHeater` | `TARGET_TEMPERATURE` | yes (`power`) | yes |
| E2 | `TARGET_TEMPERATURE \| ON_OFF` | inherited | `STATE_ON/OFF` |
| **E3** | `TARGET_TEMPERATURE` only | inherited | `STATE_ON/OFF` |
| **C3** | `TARGET_TEMPERATURE` only | override (`dhw_power`) | `STATE_ON/OFF` |
| **E6** | `TARGET_TEMPERATURE` only | override | `STATE_ON/OFF` |
| CD | `TARGET_TEMPERATURE \| OPERATION_MODE` | inherited | inherited |

E3 / E6 / C3 fully implement on/off (working `turn_on`/`turn_off`, and `current_operation` returns `STATE_ON`/`STATE_OFF`) but don't declare `WaterHeaterEntityFeature.ON_OFF`, unlike E2.

## Change

Add `WaterHeaterEntityFeature.ON_OFF` (alongside `TARGET_TEMPERATURE`) to E3, E6 and C3, so the declared feature set matches the implemented behavior and is consistent with E2.

## Honest scope note

This is a **consistency / self-documentation** change, not a bug fix. I verified against the current Home Assistant `water_heater` frontend that the on/off affordance is **not** gated on the `ON_OFF` feature flag (water_heater isn't in `SPECIAL_TOGGLE_ACTIONS`, and `turn_on`/`turn_off` are registered unconditionally), so **there is no functional UI change** — those services were already callable on E3/E6/C3. The value is that the advertised capabilities now correctly describe the entity.

If you'd rather not add feature flags that don't change behavior, feel free to close this one — it's the lowest-priority item in the review.

## Scope

- Single file: `custom_components/midea_ac_lan/water_heater.py`, three `supported_features` overrides.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)