### PR TITLE
fix(vscode): sync editor config with pre-commit/CI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,18 @@
 {
   "python.defaultInterpreterPath": ".venv/bin/python",
-  "python.testing.pytestArgs": ["tests"],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": false,
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+  "[json][jsonc][yaml][markdown][html][css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "prettier.tabWidth": 2
 }


### PR DESCRIPTION
## Summary

Bring `.vscode/settings.json` in sync with what the pre-commit hooks and CI (`linter.yml`) actually enforce. The committed VS Code config had drifted from the tooling, so editing in the IDE didn't match what gets rewritten/checked at commit time.

## Changes

- **Remove dead pytest config.** `python.testing.pytestArgs: ["tests"]` + `pytestEnabled: true` pointed at a `tests/` dir that doesn't exist — there's no `pytest` dependency and no test suite in this repo (per AGENTS.md). Set `pytestEnabled: false` so VS Code stops trying to discover a non-existent suite.
- **Format-on-save for Python via Ruff.** Adds `charliermarsh.ruff` as the `[python]` default formatter with `formatOnSave` + `source.fixAll`/`source.organizeImports`, mirroring the `ruff` + `ruff-format` pre-commit hooks. Previously the editor did nothing on save, so code only got formatted at commit/CI.
- **Format-on-save for JSON/YAML/Markdown via Prettier** with `prettier.tabWidth: 2`, mirroring the `prettier` hook (`--tab-width 2`).

These formatters match the already-recommended extensions in `.vscode/extensions.json` (`charliermarsh.ruff`, `esbenp.prettier-vscode`).

## Notes / not changed

- POSIX `.venv/bin/...` paths in `settings.json`/`launch.json` are left as-is (the Python extension resolves the interpreter; changing them was out of scope for this sync).

## Verification

- `settings.json` is valid JSON.
- `pre-commit run prettier --files .vscode/settings.json` → Passed.
- Full commit passed all pre-commit hooks (commitlint included).