### PR TITLE
feat(ac): add icons for silent and full mode

### DIFF
--- a/custom_components/midea_ac_lan/icons.json
+++ b/custom_components/midea_ac_lan/icons.json
@@ -1,0 +1,16 @@
+{
+  "entity": {
+    "climate": {
+      "climate_key": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "silent": "mdi:fan-clock",
+              "full": "mdi:fan-alert"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# PR Description

## Reason & Detail

This adds icons for the modes `silent` and `full`. 

Before: 
<img width="195" height="305" alt="image" src="https://github.com/user-attachments/assets/6cfbe178-507a-4975-a47f-7c0fb2745f8a" />

After: 

<img width="194" height="317" alt="image" src="https://github.com/user-attachments/assets/6c286fba-962d-4196-8e6b-f19fa85375b1" />

Noticed them missing after https://github.com/wuwentao/midea_ac_lan/commit/f92a068a4cba30aca0042a24605b325277bc74ff
