### PR TITLE
fix: avoid deprecated CONCENTRATION_* constants on HA >= 2026.7

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -5,8 +5,8 @@ from typing import Any
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
+    MAJOR_VERSION,
+    MINOR_VERSION,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
     Platform,
@@ -19,6 +19,27 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolume,
 )
+
+# HA 2026.7 added UnitOfDensity/UnitOfRatio, and HA 2026.8 started deprecating
+# CONCENTRATION_MICROGRAMS_PER_CUBIC_METER / CONCENTRATION_PARTS_PER_MILLION in favor of
+# them (scheduled for removal in HA 2027.8). Both old and new names resolve to the
+# identical runtime string ("μg/m³" / "ppm"), so this is purely cosmetic. This
+# integration's floor is HA 2024.4.1, where UnitOfDensity/UnitOfRatio do not exist yet,
+# so branch on the HA version like the rest of this codebase does for newer HA APIs (see
+# other MAJOR_VERSION/MINOR_VERSION usages, e.g. midea_entity.py).
+if (MAJOR_VERSION, MINOR_VERSION) >= (2026, 7):
+    from homeassistant.const import (  # pylint: disable=E0611
+        UnitOfDensity,
+        UnitOfRatio,
+    )
+
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    CONCENTRATION_PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
+else:
+    from homeassistant.const import (  # type: ignore[no-redef]
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_MILLION,
+    )
 from midealocal.devices.a1 import DeviceAttributes as A1Attributes
 from midealocal.devices.ac import DeviceAttributes as ACAttributes
 from midealocal.devices.ad import DeviceAttributes as ADAttributes


### PR DESCRIPTION
# PR Description

## Reason & Detail

`custom_components/midea_ac_lan/midea_devices.py` imports `CONCENTRATION_PARTS_PER_MILLION`
and `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` from `homeassistant.const` (used as the `unit`
for `tvoc`/`co2` and `pm25`/`hcho` sensors respectively). Home Assistant deprecated both names
as of **HA 2026.8** in favor of `UnitOfRatio.PARTS_PER_MILLION` and
`UnitOfDensity.MICROGRAMS_PER_CUBIC_METER`, scheduled for removal in **HA 2027.8**.

**A naive rename would have broken every HA version this integration currently supports.**
While investigating, I confirmed against real installed `homeassistant` wheels that
`UnitOfDensity`/`UnitOfRatio` were only added in **HA 2026.7** — they do not exist in this
repo's floor (`manifest.json` minimum: **2024.4.1**), nor in the two other versions this repo
tests/pins in `pyproject.toml` (**2024.12.1** for py3.13, **2026.3.1** for py3.14). A blind
`from homeassistant.const import UnitOfDensity, UnitOfRatio` would raise `ImportError` on all
three of them.

So this PR follows the version-branching convention this codebase already uses for newer HA
APIs (see `(MAJOR_VERSION, MINOR_VERSION)` checks in `midea_entity.py`, `config_flow.py`,
`climate.py`): use the new enums on HA ≥ 2026.7, fall back to the deprecated constants
otherwise. Both names resolve to the identical runtime string on any given HA version, so this
is a pure no-op behavior change — same `unit` values before and after, on every HA version.

Downstream, all 12 existing `"unit": CONCENTRATION_...` usage sites in `midea_devices.py` are
untouched; they still reference the same module-level names, which are now bound conditionally
at import time.

### Verification

- **Baseline** (before this change, on `main`): `uv run pre-commit run --all-files` (ruff,
  ruff format, mypy, pylint, codespell, pyupgrade) — all pass on the default py3.12 / HA
  2024.4.1 env.
- **After this change**: same suite passes, plus:
  - `mypy` and `pylint` (10.00/10) also verified clean under `--python 3.13` (HA 2024.12.1)
    and `--python 3.14` (HA 2026.3.1) — this repo's other two pinned environments.
  - Loaded `midea_devices.py` directly and confirmed, on py3.12/HA 2024.4.1, py3.13/HA
    2024.12.1, and py3.14/HA 2026.3.1: module imports without error, the `else` (old
    constant) branch is taken, and sample entity configs (`ADAttributes.co2`,
    `ADAttributes.pm25`) resolve to the exact same values as on unmodified `main` (one
    thing I checked along the way: HA itself uses `µ` U+00B5 MICRO SIGN in this constant
    through 2024.12.1 but switched to `μ` U+03BC GREEK MU by 2026.3.1 — entirely
    independent of this PR; this change never touches that value, it only passes through
    whatever HA already provides for a given version).
  - Installed real `homeassistant==2026.8.0` (current latest, has the new enums +
    deprecation) in a scratch venv and loaded `midea_devices.py` against it directly: the
    `if` branch is taken, and the same sample entity configs resolve to
    `UnitOfRatio.PARTS_PER_MILLION` / `UnitOfDensity.MICROGRAMS_PER_CUBIC_METER`, which
    `== "ppm"` / `== "μg/m³"` as expected.
  - A runtime-value-only test can't distinguish old vs. new import paths (they're equal by
    design), so verification here is import/attribute-level and cross-version rather than a
    single value assertion.

### Not able to validate

- Cannot test against a real Midea device end-to-end.
- The `prettier` and `commitlint` pre-commit hooks could not run in my sandbox (network
  restricted `npm install` of a git-based package — reproducible on a clean checkout,
  unrelated to this change). `prettier` doesn't process `.py` files, and `commitizen check`
  (a native Python implementation of the same Conventional Commits check `commitlint`
  performs) passed against the commit message, so the message is compliant even though
  `commitlint` itself didn't execute locally. CI should exercise both normally.

## Related issue

N/A — no existing issue filed for this; found via an audit of deprecated HA constant usage
ahead of the HA 2027.8 removal.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
