### PR TITLE
feat(b0): expose mode, fire power and child lock entities

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -967,6 +967,21 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
                 "unit": UnitOfTime.SECONDS,
                 "state_class": SensorStateClass.MEASUREMENT,
             },
+            B0Attributes.mode: {
+                "type": Platform.SENSOR,
+                "name": "Mode",
+                "icon": "mdi:chef-hat",
+            },
+            B0Attributes.fire_power: {
+                "type": Platform.SENSOR,
+                "name": "Fire Power",
+                "icon": "mdi:fire",
+            },
+            B0Attributes.child_lock: {
+                "type": Platform.LOCK,
+                "translation_key": "child_lock",
+                "name": "Child Lock",
+            },
         },
     },
     0xB1: {


### PR DESCRIPTION
Relates to #908

## Problem

`midealocal` already parses `mode`, `fire_power` and `child_lock` for B0 microwave/oven devices,
but they were never mapped to Home Assistant entities in this integration — the data was silently
dropped.

## Fix

Add them as extra (opt-in) entities:
- `mode` and `fire_power` as read-only sensors, matching the existing `status`/`time_remaining`
  pattern
- `child_lock` as a lock entity, for consistency with every other device type in this file

Note: B0's `set_attribute()` is currently a no-op in `midealocal`, so `child_lock` will read
correctly but cannot be toggled from Home Assistant until that's wired up upstream.

## Scope

Small, self-contained change — one file, 15 lines added, no existing behavior touched.
