### PR TITLE
chore: remove myself as codeowner

### DIFF
--- a/custom_components/midea_ac_lan/manifest.json
+++ b/custom_components/midea_ac_lan/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": [
     "@wuwentao",
     "@rokam",
-    "@chemelli74",
     "@caibinqing"
   ],
   "config_flow": true,


### PR DESCRIPTION
Hi everyone,

We are moving the integration to the Home Assistant Core, so you will find a Midea integration ready to use there.

For this reason, I’m removing myself as a code owner here, as we were unfortunately unable to find a suitable path forward for migrating the integration with the owner of this repository.

Please continue to support both `midea-local` and the Home Assistant Core integration!

Thanks to everyone who contributed and supported the project along the way!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project ownership metadata by removing a listed code owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->