### PR TITLE
feat(ac): support iECO query and set

### DIFF
--- a/custom_components/midea_ac_lan/midea_devices.py
+++ b/custom_components/midea_ac_lan/midea_devices.py
@@ -563,6 +563,12 @@ MIDEA_DEVICES: dict[int, dict[str, dict[str, Any] | str]] = {
                 "name": "Self Clean",
                 "icon": "mdi:air-filter",
             },
+            ACAttributes.ieco: {
+                "type": Platform.SWITCH,
+                "translation_key": "ieco",
+                "name": "iECO",
+                "icon": "mdi:leaf",
+            },
             ACAttributes.full_dust: {
                 "type": Platform.BINARY_SENSOR,
                 "translation_key": "full_dust",

--- a/custom_components/midea_ac_lan/translations/de.json
+++ b/custom_components/midea_ac_lan/translations/de.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Selbstreinigung"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Ton"
       },

--- a/custom_components/midea_ac_lan/translations/en.json
+++ b/custom_components/midea_ac_lan/translations/en.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Self Clean"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Sound"
       },

--- a/custom_components/midea_ac_lan/translations/es.json
+++ b/custom_components/midea_ac_lan/translations/es.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Self Clean"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Sound"
       },

--- a/custom_components/midea_ac_lan/translations/fr.json
+++ b/custom_components/midea_ac_lan/translations/fr.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Auto-nettoyage"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Son"
       },

--- a/custom_components/midea_ac_lan/translations/hu.json
+++ b/custom_components/midea_ac_lan/translations/hu.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Self Clean"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Sound"
       },

--- a/custom_components/midea_ac_lan/translations/it.json
+++ b/custom_components/midea_ac_lan/translations/it.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Autopulizia"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Suono"
       },

--- a/custom_components/midea_ac_lan/translations/ru.json
+++ b/custom_components/midea_ac_lan/translations/ru.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Self Clean"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Sound"
       },

--- a/custom_components/midea_ac_lan/translations/sk.json
+++ b/custom_components/midea_ac_lan/translations/sk.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Self Clean"
       },
+      "ieco": {
+        "name": "iECO"
+      },
       "sound": {
         "name": "Sound"
       },

--- a/custom_components/midea_ac_lan/translations/zh-Hans.json
+++ b/custom_components/midea_ac_lan/translations/zh-Hans.json
@@ -965,6 +965,9 @@
       "self_clean": {
         "name": "Self Clean"
       },
+      "ieco": {
+        "name": "iECO 节能"
+      },
       "sound": {
         "name": "Sound"
       },

--- a/doc/AC.md
+++ b/doc/AC.md
@@ -133,6 +133,7 @@ Known settings:
 | switch.{DEVICEID}\_comfort_mode                | switch        | Comfort Mode                     |
 | switch.{DEVICEID}\_dry                         | switch        | Dry                              |
 | switch.{DEVICEID}\_eco_mode                    | switch        | ECO Mode                         |
+| switch.{DEVICEID}\_ieco                        | switch        | iECO                             |
 | switch.{DEVICEID}\_indirect_wind               | switch        | Indirect Wind                    |
 | switch.{DEVICEID}\_natural_wind                | switch        | Natural Wind                     |
 | switch.{DEVICEID}\_prompt_tone                 | switch        | Prompt Tone                      |

--- a/doc/AC_hans.md
+++ b/doc/AC_hans.md
@@ -108,6 +108,7 @@
 | switch.{DEVICEID}\_comfort_mode                | switch        | Comfort Mode                     | 舒省模式          |
 | switch.{DEVICEID}\_dry                         | switch        | Dry                              | 干燥              |
 | switch.{DEVICEID}\_eco_mode                    | switch        | ECO Mode                         | ECO模式           |
+| switch.{DEVICEID}\_ieco                        | switch        | iECO                             | iECO 节能         |
 | switch.{DEVICEID}\_indirect_wind               | switch        | Indirect Wind                    | 防直吹            |
 | switch.{DEVICEID}\_natural_wind                | switch        | Natural Wind                     | 自然风            |
 | switch.{DEVICEID}\_prompt_tone                 | switch        | Prompt Tone                      | 提示音            |


### PR DESCRIPTION
## Summary

Adds an opt-in **iECO** switch entity for `0xAC` (Air Conditioner) devices, exposing the new-protocol iECO tag (`0x00E3`). Fixes #969.

iECO is a **separate energy-saving mode from ECO**:
- **ECO Mode** (already supported) overrides the user's setpoint and runs at a fixed ~24 °C target.
- **iECO** keeps the user's setpoint and modulates the compressor adaptively to reduce power. It can only be enabled from the Midea/MSmartHome app today and is silently dropped on a power cycle — so exposing it in Home Assistant lets automations re-enable it after each start (e.g. solar-surplus setups).

Follows the existing `self_clean` / `out_silent` switch pattern.

## Change

**`custom_components/midea_ac_lan/midea_devices.py`** — add `ACAttributes.ieco` as a `SWITCH` entity in the `0xAC` definition:

```python
ACAttributes.ieco: {
    "type": Platform.SWITCH,
    "translation_key": "ieco",
    "name": "iECO",
    "icon": "mdi:leaf",
},
```

- Adds the `ieco` UI string to all locale files under `translations/`.
- Documents the switch in `doc/AC.md` and `doc/AC_hans.md`.

## Dependency

Requires a `midea-lan` release that exposes `DeviceAttributes.ieco` and the iECO query/set protocol wiring — companion PR: wuwentao/midea-lan#70. The `requirements` pin in `manifest.json` will be bumped manually to sync once that release is cut. (mypy flags `ieco` as missing until then, matching the flow used for #839.)

## Testing

- `ruff check` / `ruff format --check` — pass
- `prettier`, `codespell`, `check-json` pre-commit hooks — pass
- All translation JSON files validated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an iECO switch for compatible air conditioners, allowing energy-saving mode to be enabled or disabled.
  - Added a leaf icon and localized display names across supported languages.

- **Documentation**
  - Updated air conditioner documentation to include the new iECO switch entity and its energy-saving function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->