### PR TITLE
fix(ac): sync climate.py with lib capabilities array format

### DIFF
--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -506,8 +506,8 @@ class MideaACClimate(MideaClimate):
             return self._customize_swing
         caps = getattr(self._device, "capabilities", {})
         swing_modes = caps.get("swing_modes")
-        if isinstance(swing_modes, dict):
-            return bool(swing_modes.get("vertical") or swing_modes.get("horizontal"))
+        if isinstance(swing_modes, list):
+            return bool("vertical" in swing_modes or "horizontal" in swing_modes)
         return True
 
     @property
@@ -522,17 +522,17 @@ class MideaACClimate(MideaClimate):
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return list(self._mode_index)
-        modes_map = caps.get("modes")
-        if not isinstance(modes_map, dict):
+        modes_list = caps.get("modes")
+        if not isinstance(modes_list, list):
             return list(self._mode_index)
         hvac_modes = [HVACMode.OFF]
-        if modes_map.get("auto"):
+        if "auto" in modes_list:
             hvac_modes.append(HVACMode.AUTO)
-        if modes_map.get("cool"):
+        if "cool" in modes_list:
             hvac_modes.append(HVACMode.COOL)
-        if modes_map.get("dry"):
+        if "dry" in modes_list:
             hvac_modes.append(HVACMode.DRY)
-        if modes_map.get("heat"):
+        if "heat" in modes_list:
             hvac_modes.append(HVACMode.HEAT)
         # fan-only is always available on AC devices
         hvac_modes.append(HVACMode.FAN_ONLY)
@@ -559,8 +559,8 @@ class MideaACClimate(MideaClimate):
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return all_presets
-        modes_map = caps.get("modes")
-        has_heat = isinstance(modes_map, dict) and bool(modes_map.get("heat"))
+        modes_list = caps.get("modes")
+        has_heat = isinstance(modes_list, list) and "heat" in modes_list
         keep = {
             PRESET_NONE: True,
             PRESET_COMFORT: True,
@@ -666,11 +666,11 @@ class MideaACClimate(MideaClimate):
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return list(self._fan_speeds.keys())
-        fan_speeds_map = caps.get("fan_speeds")
-        if not isinstance(fan_speeds_map, dict):
+        fan_speeds_list = caps.get("fan_speeds")
+        if not isinstance(fan_speeds_list, list):
             return list(self._fan_speeds.keys())
         # stepless/inverter fan: expose every discrete speed, not just "full"
-        if fan_speeds_map.get("custom"):
+        if "custom" in fan_speeds_list:
             return list(self._fan_speeds.keys())
         cap_by_fan = {
             FAN_SILENT: "silent",
@@ -681,9 +681,7 @@ class MideaACClimate(MideaClimate):
             FAN_AUTO: "auto",
         }
         modes = [
-            name
-            for name in self._fan_speeds
-            if fan_speeds_map.get(cap_by_fan.get(name, ""))
+            name for name in self._fan_speeds if cap_by_fan.get(name) in fan_speeds_list
         ]
         return modes or list(self._fan_speeds.keys())
 

--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -505,6 +505,8 @@ class MideaACClimate(MideaClimate):
         if self._customize_swing is not None:
             return self._customize_swing
         caps = getattr(self._device, "capabilities", {})
+        if not isinstance(caps, dict):
+            return True
         swing_modes = caps.get("swing_modes")
         if isinstance(swing_modes, list):
             return bool("vertical" in swing_modes or "horizontal" in swing_modes)
@@ -520,7 +522,7 @@ class MideaACClimate(MideaClimate):
         if self._customize_hvac_modes is not None:
             return self._customize_hvac_modes
         caps = getattr(self._device, "capabilities", {})
-        if not caps:
+        if not isinstance(caps, dict) or not caps:
             return list(self._mode_index)
         modes_list = caps.get("modes")
         if not isinstance(modes_list, list):
@@ -557,7 +559,7 @@ class MideaACClimate(MideaClimate):
         if self._customize_preset_modes is not None:
             return self._customize_preset_modes
         caps = getattr(self._device, "capabilities", {})
-        if not caps:
+        if not isinstance(caps, dict) or not caps:
             return all_presets
         modes_list = caps.get("modes")
         has_heat = isinstance(modes_list, list) and "heat" in modes_list
@@ -664,7 +666,7 @@ class MideaACClimate(MideaClimate):
         if self._customize_fan_modes is not None:
             return self._customize_fan_modes
         caps = getattr(self._device, "capabilities", {})
-        if not caps:
+        if not isinstance(caps, dict) or not caps:
             return list(self._fan_speeds.keys())
         fan_speeds_list = caps.get("fan_speeds")
         if not isinstance(fan_speeds_list, list):

--- a/custom_components/midea_ac_lan/climate.py
+++ b/custom_components/midea_ac_lan/climate.py
@@ -505,8 +505,9 @@ class MideaACClimate(MideaClimate):
         if self._customize_swing is not None:
             return self._customize_swing
         caps = getattr(self._device, "capabilities", {})
-        if "swing_vertical" in caps or "swing_horizontal" in caps:
-            return bool(caps.get("swing_vertical") or caps.get("swing_horizontal"))
+        swing_modes = caps.get("swing_modes")
+        if isinstance(swing_modes, dict):
+            return bool(swing_modes.get("vertical") or swing_modes.get("horizontal"))
         return True
 
     @property
@@ -521,18 +522,21 @@ class MideaACClimate(MideaClimate):
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return list(self._mode_index)
-        modes = [HVACMode.OFF]
-        if caps.get("auto_mode"):
-            modes.append(HVACMode.AUTO)
-        if caps.get("cool_mode"):
-            modes.append(HVACMode.COOL)
-        if caps.get("dry_mode"):
-            modes.append(HVACMode.DRY)
-        if caps.get("heat_mode"):
-            modes.append(HVACMode.HEAT)
+        modes_map = caps.get("modes")
+        if not isinstance(modes_map, dict):
+            return list(self._mode_index)
+        hvac_modes = [HVACMode.OFF]
+        if modes_map.get("auto"):
+            hvac_modes.append(HVACMode.AUTO)
+        if modes_map.get("cool"):
+            hvac_modes.append(HVACMode.COOL)
+        if modes_map.get("dry"):
+            hvac_modes.append(HVACMode.DRY)
+        if modes_map.get("heat"):
+            hvac_modes.append(HVACMode.HEAT)
         # fan-only is always available on AC devices
-        modes.append(HVACMode.FAN_ONLY)
-        return modes
+        hvac_modes.append(HVACMode.FAN_ONLY)
+        return hvac_modes
 
     @property
     def preset_modes(self) -> list[str]:
@@ -555,13 +559,15 @@ class MideaACClimate(MideaClimate):
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return all_presets
+        modes_map = caps.get("modes")
+        has_heat = isinstance(modes_map, dict) and bool(modes_map.get("heat"))
         keep = {
             PRESET_NONE: True,
             PRESET_COMFORT: True,
             PRESET_ECO: bool(caps.get("eco")),
             PRESET_BOOST: bool(caps.get("turbo_cool") or caps.get("turbo_heat")),
             PRESET_SLEEP: True,
-            PRESET_AWAY: bool(caps.get("heat_mode")),
+            PRESET_AWAY: has_heat,
         }
         return [preset for preset in all_presets if keep[preset]]
 
@@ -660,19 +666,24 @@ class MideaACClimate(MideaClimate):
         caps = getattr(self._device, "capabilities", {})
         if not caps:
             return list(self._fan_speeds.keys())
+        fan_speeds_map = caps.get("fan_speeds")
+        if not isinstance(fan_speeds_map, dict):
+            return list(self._fan_speeds.keys())
         # stepless/inverter fan: expose every discrete speed, not just "full"
-        if caps.get("fan_custom"):
+        if fan_speeds_map.get("custom"):
             return list(self._fan_speeds.keys())
         cap_by_fan = {
-            FAN_SILENT: "fan_silent",
-            FAN_LOW: "fan_low",
-            FAN_MEDIUM: "fan_medium",
-            FAN_HIGH: "fan_high",
-            FAN_FULL_SPEED: "fan_custom",
-            FAN_AUTO: "fan_auto",
+            FAN_SILENT: "silent",
+            FAN_LOW: "low",
+            FAN_MEDIUM: "medium",
+            FAN_HIGH: "high",
+            FAN_FULL_SPEED: "custom",
+            FAN_AUTO: "auto",
         }
         modes = [
-            name for name in self._fan_speeds if caps.get(cap_by_fan.get(name, ""))
+            name
+            for name in self._fan_speeds
+            if fan_speeds_map.get(cap_by_fan.get(name, ""))
         ]
         return modes or list(self._fan_speeds.keys())
 


### PR DESCRIPTION
## Summary

Adapts `MideaACClimate` to read capabilities in the array format introduced by `midea-lan` PR #91.

## Library evolution

### PR #87: Temperature limits refactor
- Moved temperature limits to nested `capabilities["temperature"][mode]["min"|"max"]` map
- **No climate.py impact** — device layer handles this via `min_temperature`/`max_temperature` attributes

### PR #88: Modes/swing/fan capability refactor (nested dicts)
Collapsed flat B5 capability keys into nested **dict** maps:
- `heat_mode`, `cool_mode`, ... → `capabilities["modes"]["heat"|"cool"|...]` (bool values)
- `swing_horizontal`, `swing_vertical` → `capabilities["swing_modes"]["horizontal"|"vertical"]` (bool)
- `fan_silent`, `fan_low`, ... → `capabilities["fan_speeds"]["silent"|"low"|...]` (bool)

### PR #91: Unify capabilities to arrays (current format)
Changed nested dicts to **arrays** for consistency:
- `capabilities["modes"]` → `["auto", "cool", "dry", "heat"]` (subset based on device)
- `capabilities["swing_modes"]` → `["horizontal", "vertical"]`
- `capabilities["fan_speeds"]` → `["silent", "low", "medium", "high", "auto", "custom"]`

## Changes in this PR

Updated four methods in `MideaACClimate` that read B5 capabilities to use array membership checks instead of dict key lookups:

1. **`_capability_swing()`** (line ~508):
   - Old: `isinstance(swing_modes, dict)` → `swing_modes.get("vertical")`
   - New: `isinstance(swing_modes, list)` → `"vertical" in swing_modes`

2. **`hvac_modes` property** (line ~522):
   - Old: `isinstance(modes_map, dict)` → `modes_map.get("auto")`
   - New: `isinstance(modes_list, list)` → `"auto" in modes_list`

3. **`preset_modes` property** (line ~559):
   - Old: `modes_map.get("heat")`
   - New: `"heat" in modes_list`

4. **`fan_modes` property** (line ~666):
   - Old: `isinstance(fan_speeds_map, dict)` → `fan_speeds_map.get("custom")`
   - New: `isinstance(fan_speeds_list, list)` → `"custom" in fan_speeds_list`
   - Simplified list comprehension: `cap_by_fan.get(name) in fan_speeds_list`

## Backward compatibility

All changes check `isinstance(list)` before accessing array elements and fall back to defaults when the expected structure is missing, so the code remains compatible with older library versions.

## Testing

- ✅ `uv run ruff format` — passed
- ✅ `uv run ruff check` — passed
- ✅ `scripts/mypy.sh` — passed (Python 3.12, no issues)
- ✅ All pre-commit hooks — passed

## Related

- Refs: wuwentao/midea-lan#87 (temperature limits)
- Refs: wuwentao/midea-lan#88 (modes/swing/fan nested dicts, superseded by #91)
- Refs: wuwentao/midea-lan#91 (unified array format, **current format**)
- Original B5 capability support: #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with air conditioners that report capability information in list format.
  * Preserved expected defaults when capability information is missing, empty, or provided in an unsupported format.
  * Corrected availability detection for swing modes, HVAC modes, presets, and fan modes.
  * Maintained existing behavior for stepless fan control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->