### PR TITLE
fix(config-flow): explain token account limitations

### DIFF
--- a/custom_components/midea_ac_lan/translations/de.json
+++ b/custom_components/midea_ac_lan/translations/de.json
@@ -22,7 +22,7 @@
           "account": "Konto",
           "password": "Passwort"
         },
-        "description": "Mit dem Midea-Konto anmelden. Das Konto wird nur verwendet, um die Geräteinformationen zu erhalten.\nDie Konfiguration kann wieder entfernt werden, nachdem alle Geräte konfiguriert wurden.",
+        "description": "Melden Sie sich an und rufen Sie das Geräte-Token ab.\n\n\nDerzeit können nur persönliche SmartHome- und Meiju-Konten Geräte-Tokens abrufen. Details finden Sie in der README-Dokumentation.",
         "title": "Login"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/en.json
+++ b/custom_components/midea_ac_lan/translations/en.json
@@ -22,7 +22,7 @@
           "account": "Account",
           "password": "Password"
         },
-        "description": "Login and storage your Midea account only for getting the appliance info.\nYou can remove this configuration after all appliance configured.",
+        "description": "Login and get the appliance token.\n\n\nCurrently, only personal SmartHome and Meiju accounts can retrieve appliance Tokens. See README doc for details.",
         "title": "Login"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/es.json
+++ b/custom_components/midea_ac_lan/translations/es.json
@@ -22,7 +22,7 @@
           "account": "Cuenta",
           "password": "Contraseña"
         },
-        "description": "Inicie sesión y guarde su cuenta Midea solo para obtener la información del electrodoméstico.\nPuede eliminar esta configuración después de haber configurado todos los dispositivos.",
+        "description": "Inicie sesión y obtenga el token del electrodoméstico.\n\n\nActualmente, solo las cuentas personales de SmartHome y Meiju pueden recuperar los Tokens de electrodomésticos. Consulte la documentación README para obtener más detalles.",
         "title": "Iniciar sesión"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/fr.json
+++ b/custom_components/midea_ac_lan/translations/fr.json
@@ -22,7 +22,7 @@
           "account": "Account",
           "password": "Password"
         },
-        "description": "Login and storage your Midea account only for getting the appliance info.\nYou can remove this configuration after all appliance configured.",
+        "description": "Connectez-vous et récupérez le token de l'appareil.\n\n\nActuellement, seuls les comptes personnels SmartHome et Meiju peuvent récupérer les Tokens des appareils. Consultez la documentation README pour plus de détails.",
         "title": "Login"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/hu.json
+++ b/custom_components/midea_ac_lan/translations/hu.json
@@ -22,7 +22,7 @@
           "account": "Fiók",
           "password": "Jelszó"
         },
-        "description": "Jelentkezzen be és tárolja el Midea-fiókját, kizárólag a készülékei információinak a megszerzéséhez.\nAz összes készülékének beállítása után eltávolíthatja ezt a konfigurációt.",
+        "description": "Jelentkezzen be, és kérje le a készülék tokenjét.\n\n\nJelenleg csak személyes SmartHome- és Meiju-fiókokkal lehet lekérni a készülékek Tokenjeit. Részletekért lásd a README dokumentációt.",
         "title": "Bejelentkezés"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/it.json
+++ b/custom_components/midea_ac_lan/translations/it.json
@@ -22,7 +22,7 @@
           "account": "Account",
           "password": "Password"
         },
-        "description": "Accedi e salva il tuo account Midea solo per ottenere le informazioni sugli elettrodomestici.\nPuoi rimuovere questa configurazione dopo aver completato la configurazione di tutti gli elettrodomestici.",
+        "description": "Accedi e ottieni il token dell'elettrodomestico.\n\n\nAttualmente, solo gli account personali SmartHome e Meiju possono recuperare i Token degli elettrodomestici. Per i dettagli, consulta la documentazione README.",
         "title": "Accesso"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/ru.json
+++ b/custom_components/midea_ac_lan/translations/ru.json
@@ -22,7 +22,7 @@
           "account": "Аккаунт",
           "password": "Пароль"
         },
-        "description": "Login and storage your Midea account only for getting the appliance info.\nYou can remove this configuration after all appliance configured.",
+        "description": "Войдите в аккаунт и получите токен устройства.\n\n\nВ настоящее время токены устройств могут получать только личные аккаунты SmartHome и Meiju. Подробности см. в документации README.",
         "title": "Login"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/sk.json
+++ b/custom_components/midea_ac_lan/translations/sk.json
@@ -22,7 +22,7 @@
           "account": "Account",
           "password": "Password"
         },
-        "description": "Login and storage your Midea account only for getting the appliance info.\nYou can remove this configuration after all appliance configured.",
+        "description": "Prihláste sa a získajte token zariadenia.\n\n\nAktuálne môžu Tokeny zariadení získať iba osobné účty SmartHome a Meiju. Podrobnosti nájdete v dokumentácii README.",
         "title": "Login"
       },
       "discovery": {

--- a/custom_components/midea_ac_lan/translations/zh-Hans.json
+++ b/custom_components/midea_ac_lan/translations/zh-Hans.json
@@ -22,7 +22,7 @@
           "account": "账号",
           "password": "密码"
         },
-        "description": "登录并保存你的美的账户，仅用于获取添加设备时设备信息\n添加设备完成后，你可以删除该配置",
+        "description": "登录并获取设备 Token。\n\n\n目前仅个人 SmartHome 和 Meiju 账号可获取设备 Token。详情请参考 README 文档。",
         "title": "登录"
       },
       "discovery": {


### PR DESCRIPTION
## Summary
- Add a login-form notice that only personal SmartHome and Meiju accounts can retrieve appliance Tokens.
- Link the notice to the README Important Notice section.
- Apply the notice to all integration translation files.

## Verification
- Translation JSON validation passed.
- Home Assistant config-flow translation loading passed.
- Login flow smoke test passed; account/password/server fields remain unchanged.
- Pre-commit checks passed.
- git diff --check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated login instructions across supported languages.
  * Clarified that login retrieves an appliance token.
  * Explained that token retrieval currently supports only personal SmartHome and Meiju accounts.
  * Added a reference to the README for further details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->